### PR TITLE
Add Fortran tools for manipulating ephemeris files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+FORTRAN=gfortran
+FPATH=fortran
 CC=gcc
 CPATH=src
 LIBPATH=$(CPATH)/lib
@@ -18,6 +20,8 @@ LIBNAMESHARED=libnovas.so.$(SOVER)
 endif
 LIBNAMES=$(LIBNAMESTATIC) $(LIBNAMESHARED)
 PROGNAMES=example checkout-mp checkout-stars checkout-stars-full cio_file
+FPROGNAMES=asc2eph.e testeph1.e
+
 ifneq ($(shell uname -m), i386)
     CFLAGS += -fPIC
 endif
@@ -27,6 +31,8 @@ all: lib progs
 lib: $(LIBNAMES)
 
 progs: $(PROGNAMES)
+
+fortran: $(FPROGNAMES)
 
 $(LIBNAMESTATIC): $(LIBOBJS)
 	ar rcs $@ $^
@@ -49,5 +55,18 @@ checkout-stars-full: $(CPATH)/checkout-stars-full.c $(LIBNAMESTATIC)
 cio_file: $(CPATH)/cio_file.c
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
+asc2eph.e: $(FPATH)/asc2eph.f
+	$(FORTRAN) $^ -o $@
+
+# testeph1.e (below) is newer and smarter, so `testeph.e` is disabled.
+# Uncomment testeph.e above if you want it and run `make testeph.e`, but it
+# requires additional manual configuration.  See fortran/userguide.txt and
+# fortran/example-configurations/*
+#testeph.e: $(FPATH)/testeph.f
+#	$(FORTRAN) $^ -o $@
+
+testeph1.e: $(FPATH)/testeph1.f
+	$(FORTRAN) $^ -o $@
+
 clean:
-	rm -f $(LIBNAMES) $(PROGNAMES) $(LIBOBJS)
+	rm -f $(LIBNAMES) $(PROGNAMES) $(FPROGNAMES) $(LIBOBJS)

--- a/fortran/README.txt
+++ b/fortran/README.txt
@@ -1,0 +1,18 @@
+The Fortran program asc2eph.f may be used to convert the ASCII versions
+of the planetary ephemerides into a binary format. The program testeph.f
+checks the binary files against the test printouts stored with the ASCII
+ephemeris files. The instructions are given in userguide.txt .
+
+The binary files are platform-dependent, and the programs requires the user
+to choose custom options within the source code before running.
+
+The binary SPK files, with extensions .bsp are portable across platforms
+so are recommended for new users. See the report documenting the format at:
+http://arxiv.org/abs/1507.04291
+
+The program testeph1.s in this directory is a preliminary version of a
+replacement for testeph.f. The new version allows the user to choose
+the units returns, with the coice of positions in the astronomical unit
+used in the construction of the particular ephpemris; the standard
+astronomical unit adopted by the IAU in 2012; or in kilometers.
+The preliminary version also allows reading of the TT-TDB time difference.

--- a/fortran/asc2eph.f
+++ b/fortran/asc2eph.f
@@ -1,0 +1,397 @@
+      PROGRAM ASC2EPH
+C
+C      ASC2EPH creates a binary format JPL Planetary Ephemeris file from
+C      one or more ascii text files.
+C
+C$ Disclaimer
+C
+C     THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE
+C     CALIFORNIA INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S.
+C     GOVERNMENT CONTRACT WITH THE NATIONAL AERONAUTICS AND SPACE
+C     ADMINISTRATION (NASA). THE SOFTWARE IS TECHNOLOGY AND SOFTWARE
+C     PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS AND IS PROVIDED "AS-IS"
+C     TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND, INCLUDING ANY
+C     WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR A
+C     PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC
+C     SECTIONS 2312-2313) OR FOR ANY PURPOSE WHATSOEVER, FOR THE
+C     SOFTWARE AND RELATED MATERIALS, HOWEVER USED.
+C
+C     IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA
+C     BE LIABLE FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT
+C     LIMITED TO, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+C     INCLUDING ECONOMIC DAMAGE OR INJURY TO PROPERTY AND LOST PROFITS,
+C     REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE ADVISED, HAVE
+C     REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
+C
+C     RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF
+C     THE SOFTWARE AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY
+C     CALTECH AND NASA FOR ALL THIRD-PARTY CLAIMS RESULTING FROM THE
+C     ACTIONS OF RECIPIENT IN THE USE OF THE SOFTWARE.
+C
+C
+C      This program, 'asc2eph', requires (via standard input) an ascii
+C      header file ('header.XXX'), followed by one or more ascii ephemeris 
+C      data files ('ascSYYYY.XXX').  All files must have the same ephemeris
+C      number, XXX.  Further, the data files must be consecutive in time
+C      with no gaps between them. 
+C
+C      By default, the output ephemeris will span the same interval as the input
+C      text file(s).  If you are interested in only a portion of data, set the
+C      below T1 and T2 to the begin and end times of the span you desire.  T1
+C      and T2 must be specified in  Julian Ephemeris Days (ET).
+C
+C      A sample sequence of files might be:
+C
+C        header.405  asc+1920.405 asc+1940.405 asc+1960.405 asc+1980.405  
+C
+C      This program is written in standard Fortran-77.  
+C
+C **********************************************************************************
+C
+C                                    *** NOTE ***
+C
+C      However, the units in which the length of a direct access record is specified 
+C      are PROCESSOR DEPENDENT.  The parameter NRECL, the number of units per word, 
+C      controls the length of a record in the direct access ephemeris.
+C      The user MUST select the correct value of NRECL by editing one of the 
+C      comemnted lines defining PARAMETER (NRECL) below.
+C
+C **********************************************************************************
+C
+C     Updated 02 March  2013 to accommodate more than 400 dynamical parameters
+C     Updated 02 August 2013 to accommodate reading of TT-TDB
+C     Updated 15 August 2013 to accommodate negative Julian dates
+C
+C **********************************************************************************
+
+      IMPLICIT NONE
+
+      INTEGER NRECL
+
+C *****  The user must choose one of the following statements  *****
+C            ( Usually NRECL = 4 is used on Unix platforms)
+
+C      PARAMETER ( NRECL = 4 )
+C      PARAMETER ( NRECL = 1 )
+
+      INTEGER OLDMAX
+      PARAMETER ( OLDMAX = 400)
+      INTEGER NMAX
+      PARAMETER ( NMAX = 1000)
+
+C **********************************************************************************
+
+       CHARACTER*6  CNAM (NMAX)
+       CHARACTER*6  TTL  (14,3)
+       CHARACTER*12 HEADER
+
+       DOUBLE PRECISION  AU
+       DOUBLE PRECISION  CVAL (NMAX)
+       DOUBLE PRECISION  DB(3000)
+       DOUBLE PRECISION  DB2Z
+       DOUBLE PRECISION  EMRAT
+       DOUBLE PRECISION  SS   (3)
+       DOUBLE PRECISION  T1, T2
+
+       INTEGER  I, IRECSZ, IN
+       INTEGER  J
+       INTEGER  K,KK,KP2,KSIZE
+       INTEGER  IPT (3,12)                         ! Pointers to number of coefficients for bodies
+       INTEGER  LPT(3)                             ! Pointer to number of coefficients for lunar librations
+       INTEGER  RPT(3)                             ! Pointer to number of coefficients for lunar euler angel rates
+       INTEGER  TPT(3)                             ! Pointer to number of coefficients for TT-TDB
+       INTEGER  N, NCON, NROUT, NCOEFF, NRW, NUMDE
+       INTEGER  OUT
+
+       LOGICAL  FIRST
+       DATA     FIRST / .TRUE. /
+
+C ***********************************************************************
+C
+C     By default, the output ephemeris will span the same interval as the
+C     input ascii data file(s).  The user may reset these to other JED's.
+C
+       DB2Z = -99999999.d0
+       T1   = -99999999.d0
+       T2   =  99999999.d0
+
+       IF(NRECL .NE. 1 .AND. NRECL .NE. 4) THEN
+         WRITE(*,*)'*** ERROR: User did not set NRECL ***'
+         STOP
+       ENDIF
+
+C      Write a fingerprint to the screen.
+
+       WRITE(*,*) ' JPL ASCII-TO-DIRECT-I/O program. ' //
+     &            ' Last modified 15-Aug-2013.'
+
+C      Read the size and number of main ephemeris records.
+C        (from header.xxx)
+
+       READ  (*,'(6X,I6)')  KSIZE
+       WRITE (*,100)              KSIZE
+100    FORMAT(/'KSIZE =',I6)
+
+       IRECSZ = NRECL * KSIZE
+
+C      Now for the alphameric heading records (GROUP 1010)
+
+       CALL  NXTGRP ( HEADER )
+
+       IF (HEADER .NE. 'GROUP   1010')  THEN
+          CALL  ERRPRT ( 1010, 'NOT HEADER' )
+       ENDIF
+
+       READ (*,'(14A6)')    TTL
+       WRITE(*,'(/(14A6))') TTL
+
+c      Read start, end and record span  (GROUP 1030)
+
+       CALL  NXTGRP ( HEADER )
+
+       IF ( HEADER .NE. 'GROUP   1030' ) THEN
+          CALL ERRPRT ( 1030, 'NOT HEADER' )
+       ENDIF
+
+       READ (*,'(3D12.0)')  SS
+
+c      Read number of constants and names of constants (GROUP 1040/4).
+
+       CALL  NXTGRP ( HEADER )
+
+       IF ( HEADER .NE. 'GROUP   1040 ') THEN
+          CALL ERRPRT ( 1040, 'NOT HEADER' )
+       ENDIF
+
+       READ (*,'(I6)')    N
+       READ (*,'(10A8)') (CNAM(I),I=1,N)
+
+       NCON = N
+
+C      Read number of values and values (GROUP 1041/4)
+
+       CALL  NXTGRP ( HEADER )
+
+       IF ( HEADER .NE. 'GROUP   1041' ) THEN
+          CALL ERRPRT ( 1041, 'NOT HEADER' )
+       ENDIF
+
+       READ (*,'(I6)')       N
+       READ (*,*)  (CVAL(I),I=1,N)
+
+       DO  I = 1, N
+           IF ( CNAM(I) .EQ. 'AU    ' )  AU    = CVAL(I)
+           IF ( CNAM(I) .EQ. 'EMRAT ' )  EMRAT = CVAL(I)
+           IF ( CNAM(I) .EQ. 'DENUM ' )  NUMDE = CVAL(I)
+       END DO
+
+       WRITE (*,'(500(/2(A8,D24.16)))') (CNAM(I),CVAL(I),I=1,N)
+
+c      Zero out pointer arrays
+
+       DO I = 1,3
+         DO J = 1,12
+           IPT(I,J) = 0
+         ENDDO
+         LPT(I) = 0
+         RPT(I) = 0
+         TPT(I) = 0
+       ENDDO
+
+C      Read pointers needed by INTERP (GROUP 1050)
+
+       CALL  NXTGRP ( HEADER )
+
+       IF ( HEADER .NE. 'GROUP   1050' ) THEN
+          CALL ERRPRT ( 1050, 'NOT HEADER' )
+       ENDIF
+
+       WRITE(*,'(/)')
+
+       DO I=1,3
+         READ (*,'(15I6)') (IPT(I,J),J=1,12),LPT(I),RPT(I),TPT(I)
+         WRITE(*,'(15I5)')(IPT(I,J),J=1,12),LPT(I),RPT(I),TPT(I)
+       ENDDO
+
+C      Open direct-access output file ('JPLEPH')
+
+       OPEN ( UNIT   = 12,
+     .        FILE   = 'JPLEPH',
+     .        ACCESS = 'DIRECT',
+     .        FORM   = 'UNFORMATTED',
+     .        RECL   = IRECSZ,
+     .        STATUS = 'NEW' )
+
+C     Read and write the ephemeris data records (GROUP 1070).
+
+      CALL  NXTGRP ( HEADER )
+
+      IF ( HEADER .NE. 'GROUP   1070' ) CALL ERRPRT(1070,'NOT HEADER')
+
+      NROUT  = 0
+      IN     = 0
+      OUT    = 0
+
+   1  continue
+
+      READ(*,'(2I6)')NRW,NCOEFF
+      IF(NRW .EQ. 0) GO TO 1
+
+      DO K=1,NCOEFF,3
+        KP2 = MIN(K+2,NCOEFF)
+        READ(*,*,IOSTAT = IN)(DB(KK),KK=K,KP2)
+        IF(IN. NE. 0)STOP ' Error reading 1st set of coeffs'
+      ENDDO
+
+      DO WHILE (       ( IN    .EQ. 0 )
+     .           .AND. ( DB(2) .LT. T2) )
+
+          IF ( 2*NCOEFF .NE. KSIZE ) THEN
+             CALL ERRPRT(NCOEFF,' 2*NCOEFF not equal to KSIZE')
+          ENDIF
+
+C         Skip this data block if the end of the interval is less
+C         than the specified start time or if the it does not begin
+C         where the previous block ended.
+
+          IF  ( (DB(2) .GE. T1) .AND. (DB(1) .GE. DB2Z) ) THEN
+
+             IF ( FIRST ) THEN
+
+C               Don't worry about the intervals overlapping
+C               or abutting if this is the first applicable
+C               interval.
+
+                DB2Z  = DB(1)
+                FIRST = .FALSE.
+             ENDIF
+
+             IF (DB(1) .NE. DB2Z ) THEN
+ 
+C               Beginning of current interval is past the end
+C               of the previous one.
+
+                CALL ERRPRT (NRW, 'Records do not overlap or abut')
+             ENDIF
+
+             DB2Z  = DB(2)
+             NROUT = NROUT + 1
+
+             WRITE (12,REC=NROUT+2,IOSTAT=OUT) (DB(K),K=1,NCOEFF)
+
+             IF ( OUT .NE. 0 ) THEN
+                CALL ERRPRT (NROUT, 
+     &                     'th record not written because of error')
+             ENDIF
+
+C            Save this block's starting date, its interval span, and its end 
+C            date.
+
+             IF (NROUT .EQ. 1) THEN
+                SS(1) = DB(1)
+                SS(3) = DB(2) - DB(1)
+             ENDIF
+             SS(2) = DB(2)
+
+C            Update the user as to our progress every 100th block.
+
+             IF ( MOD(NROUT,100) .EQ. 1 ) THEN
+                IF ( DB(1) .GE. T1 ) THEN
+                   WRITE (*,271) NROUT, DB(2)
+                ELSE
+                   WRITE (*,*) 
+     &           ' Searching for first requested record...'
+                ENDIF
+             ENDIF
+271          FORMAT (I6,
+     &              ' EPHEMERIS RECORDS WRITTEN.  LAST JED = ',
+     &              F12.2)
+
+          ENDIF
+
+          READ (*,'(2I6)',IOSTAT =IN) NRW, NCOEFF
+
+          IF(IN .EQ. 0)then
+            DO K=1,NCOEFF,3
+              KP2 = MIN(K+2,NCOEFF)
+              READ(*,*,IOSTAT = IN)(DB(KK),KK=K,KP2)
+              IF(IN. NE. 0)STOP ' Error reading nth set of coeffs'
+            ENDDO
+          ENDIF
+
+      END DO
+
+      WRITE (*,275) NROUT, DB(2)
+275   FORMAT(I6, ' EPHEMERIS RECORDS WRITTEN.  LAST JED = ',F12.2)
+
+C     Write header records onto output file.
+
+      NROUT = 1
+
+      IF(NCON .LE. OLDMAX)THEN
+         WRITE(12,REC=1,IOSTAT=OUT) TTL,(CNAM(I),I=1,OLDMAX),SS,NCON,AU,
+     &              EMRAT,IPT,NUMDE,LPT,RPT,TPT
+      ELSE
+         K = OLDMAX+1
+         WRITE(12,REC=1,IOSTAT=OUT) TTL,(CNAM(I),I=1,OLDMAX),SS,NCON,AU,
+     &              EMRAT,IPT,NUMDE,LPT,(CNAM(J),J=K,NCON),RPT,TPT
+      ENDIF
+
+      IF ( OUT .NE. 0 ) THEN
+          CALL ERRPRT ( NROUT, 'st record not written because of error')
+      ENDIF
+
+      NROUT = 2
+
+      IF(NCON .LE. OLDMAX) THEN
+         WRITE(12,REC=2,IOSTAT=OUT)(CVAL(I),I=1,OLDMAX)
+      ELSE
+         WRITE(12,REC=2,IOSTAT=OUT)(CVAL(I),I=1,NCON)
+      ENDIF
+
+      IF ( OUT .NE. 0 ) THEN
+          CALL ERRPRT ( NROUT, 'nd record not written because of error')
+      ENDIF
+
+C     We're through.  Wrap it up.
+
+      CLOSE (12)
+      STOP ' OK'
+
+      END
+
+
+      SUBROUTINE  ERRPRT (I, MSG)
+
+      CHARACTER*(*)  MSG
+      INTEGER        I
+
+      WRITE (*,200)  I, MSG
+200   FORMAT('ERROR #',I8,2X,A50)
+
+      STOP ' ERROR '
+      END
+
+
+      SUBROUTINE  NXTGRP ( HEADER )
+
+      CHARACTER*(*)  HEADER
+      CHARACTER*12   BLANK
+
+C     Start with nothing.
+
+      HEADER = ' '
+
+C     The next non-blank line we encounter is a header record.
+C     The group header and data are seperated by a blank line.
+
+      DO WHILE ( HEADER .EQ. ' ' )
+          READ (*,'(A)') HEADER
+      ENDDO
+
+C     Found the header.  Read the blank line so we can get at the data.
+
+      IF ( HEADER .NE. 'GROUP   1070' )READ (*, '(A)') BLANK
+
+      RETURN
+      END

--- a/fortran/example-configurations/README.txt
+++ b/fortran/example-configurations/README.txt
@@ -1,0 +1,9 @@
+The values of NRECL, FSIZER, and (depending on FSIZER) KSIZE must be configured
+before compiling the fortran programs.
+
+These patch files are example changes to the fortran files that are necesary
+before you can compile them.  These changes will work for most UNIX
+implementations, but see ../userguide.txt for complete documentation to make
+sure they are right for your OS and hardware.
+
+Run `make fortran` to build the fortran tools after patching them.

--- a/fortran/example-configurations/asc2eph.patch
+++ b/fortran/example-configurations/asc2eph.patch
@@ -1,0 +1,13 @@
+diff --git a/fortran/asc2eph.f b/fortran/asc2eph.f
+index 94ec070..50e402d 100644
+--- a/fortran/asc2eph.f
++++ b/fortran/asc2eph.f
+@@ -71,7 +71,7 @@ C ******************************************************************************
+ C *****  The user must choose one of the following statements  *****
+ C            ( Usually NRECL = 4 is used on Unix platforms)
+ 
+-C      PARAMETER ( NRECL = 4 )
++      PARAMETER ( NRECL = 4 )
+ C      PARAMETER ( NRECL = 1 )
+ 
+       INTEGER OLDMAX

--- a/fortran/example-configurations/testeph.patch
+++ b/fortran/example-configurations/testeph.patch
@@ -1,0 +1,49 @@
+diff --git a/fortran/testeph.f b/fortran/testeph.f
+index b58a1f1..1f08c00 100644
+--- a/fortran/testeph.f
++++ b/fortran/testeph.f
+@@ -248,7 +248,7 @@ C  NRECL=1 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN S.P. WORDS
+ C  NRECL=4 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN BYTES
+ C  (for a VAX, it is probably 1)
+ C
+-      NRECL= 
++      NRECL=4
+ 
+ C  *****************************************************************
+ 
+@@ -313,7 +313,7 @@ C  NRECL=1 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN S.P. WORDS
+ C  NRECL=4 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN BYTES
+ C  (for UNIX, it is probably 4)
+ C
+-      NRECL=
++      NRECL=4
+ 
+ C  NRFILE IS THE INTERNAL UNIT NUMBER USED FOR THE EPHEMERIS FILE
+ 
+@@ -385,7 +385,7 @@ C  *****************************************************************
+ C  NRECL=1 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN S.P. WORDS
+ C  NRECL=4 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN BYTES
+ 
+-       NRECL=
++       NRECL=4
+ 
+ C  *****************************************************************
+ 
+@@ -414,7 +414,7 @@ C  For  de423, set KSIZE to 2036
+ C  For  de424, set KSIZE to 2036
+ C  For  de430, set KSIZE to 2036
+ 
+-      KSIZE = 
++      KSIZE = 2036
+ 
+ C  *******************************************************************
+ 
+@@ -937,7 +937,7 @@ C THE USER MUST SELECT ONE OF THE FOLLOWING BY DELETING THE 'C' IN COLUMN 1
+ C ************************************************************************
+ 
+ C        CALL FSIZER1(NRECL,KSIZE,NRFILE,NAMFIL)
+-C        CALL FSIZER2(NRECL,KSIZE,NRFILE,NAMFIL)
++        CALL FSIZER2(NRECL,KSIZE,NRFILE,NAMFIL)
+ C        CALL FSIZER3(NRECL,KSIZE,NRFILE,NAMFIL)
+ 
+       IF(NRECL .EQ. 0) WRITE(*,*)'  ***** FSIZER IS NOT WORKING *****'

--- a/fortran/testeph.f
+++ b/fortran/testeph.f
@@ -1,0 +1,1119 @@
+      program testeph
+C
+C     This program reads a binary format file of ploynomial coefficients
+C     fit to the JPL/Calech Planetary and Lunar Ephemerides,
+C     interpolates the coefficients to a set of input times to
+C     evaluate the positions and velocities of the planets at those
+C     times anc compres with a test printout file.
+C
+C$ Disclaimer
+C
+C     THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE
+C     CALIFORNIA INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S.
+C     GOVERNMENT CONTRACT WITH THE NATIONAL AERONAUTICS AND SPACE
+C     ADMINISTRATION (NASA). THE SOFTWARE IS TECHNOLOGY AND SOFTWARE
+C     PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS AND IS PROVIDED "AS-IS"
+C     TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND, INCLUDING ANY
+C     WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR A
+C     PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC
+C     SECTIONS 2312-2313) OR FOR ANY PURPOSE WHATSOEVER, FOR THE
+C     SOFTWARE AND RELATED MATERIALS, HOWEVER USED.
+C
+C     IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA
+C     BE LIABLE FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT
+C     LIMITED TO, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+C     INCLUDING ECONOMIC DAMAGE OR INJURY TO PROPERTY AND LOST PROFITS,
+C     REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE ADVISED, HAVE
+C     REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
+C
+C     RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF
+C     THE SOFTWARE AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY
+C     CALTECH AND NASA FOR ALL THIRD-PARTY CLAIMS RESULTING FROM THE
+C     ACTIONS OF RECIPIENT IN THE USE OF THE SOFTWARE.
+C
+C                Version : March 25, 2013
+C
+C     Program TESTEPH
+C     ---------------
+C  
+C     TESTEPH tests the JPL ephemeris reading and interpolating routine using
+C     examples computed from the original ephemeris.
+C
+C     TESTEPH contains the reading and interpolating subroutines that are of 
+C     eventual interest to the user.  Once TESTEPH is working correctly, the 
+C     user can extract those subroutines and the installation process is complete.
+C
+C     You must supply "testpo.XXX" to TESTEPH, via standard input.  "testpo.XXX
+C     is the specially formatted text file that contains the test cases for the 
+C     ephmeris, DEXXX.
+C
+C     After the initial identifying text which is concluded by an "EOT" in
+C     columns 1-3, the test file contains the following quantities:
+C
+C         JPL Ephemeris Number
+C         calendar date
+C         Julian Ephemeris Date
+C         target number (1-Mercury, ...,3-Earth, ,,,9-Pluto, 10-Moon, 11-Sun,
+C                        12-Solar System Barycenter, 13-Earth-Moon Barycenter
+C                        14-Nutations, 15-Librations)
+C         center number (same codes as target number)
+C         coordinate number (1-x, 2-y, ... 6-zdot) 
+C         coordinate  [au, au/day]
+C
+C     For each test case input, TESTEPH
+C
+C         - computes the corresponding state from data contained 
+C           in DExxx,
+C
+C         - compares the two sets,
+C
+C         - writes an error message if the difference between
+C           any of the state components is greater than 10**(-13).
+C
+C         - writes state and difference information for every 100th
+C           test case processed.
+C
+C      This program is written in standard Fortran-77.  
+C
+C      HOWEVER, there are two parts which are compiler dependent; both have
+C      to do with opening and reading a direct-access file.  They are dealt
+C      with in the subroutine FSIZERi, i=1,3.  (There are three versions of 
+C      this subroutine.
+C
+C      1) The parameter RECL in the OPEN statement is the number of units per 
+C         record.  For some compilers, it is given in bytes; in some, it is given
+C         in single precision words.  In the subroutine FSIZER of TESTEPH, the
+C         parameter NRECL must be set to 4 if RECL is given in bytes; NRECL must 
+C         be set to 1 if RECL is given in words.  (If in doubt, use 4 for UNIX;
+C         1 for VAX and PC)
+C
+C      2) Also for the OPEN statement, the program needs to know the exact value
+C         of RECL (number of single precision words times NRECL).  Since this 
+C         varies from one JPL ephemeris to another, RECL must be determined somehow 
+C         and given to the OPEN statement.  There are three methods, depending 
+C         upon the compiler.  We have included three versions of the subroutine 
+C         FSIZER, one for each method.
+C
+C         a)  Use the INQUIRE statement to find the length of the records 
+C             automatically before opening the file.  This works for VAX's; 
+C             not in UNIX.
+C
+C         b)  Open the file with an arbitrary value of RECL, read the first record,
+C             and use the information on that record to determine the exact value
+C             of RECL.  Then, close the file and re-open it with the exact value.
+C             This seems to work for UNIX compilers as long as the initial value of
+C             RECL is less than the exact value but large enough to get the required 
+C             information from the first file.  (For other compilers, this doesn't
+C             work since you can open a file only with the exact value of RECL.)
+C
+C         c)  Hardwire the value of RECL.  This number is NRECL*1652 for DE200, 
+C             NRECL*2036 for DE405, and NRECL*1456 for DE406.
+C
+       INTEGER NMAX
+       PARAMETER (NMAX = 1000)
+
+       CHARACTER*6  NAMS(NMAX)
+       CHARACTER*3  ALF3
+
+       DOUBLE PRECISION  DEL
+       DOUBLE PRECISION  ET
+       DOUBLE PRECISION  R(6)
+       DOUBLE PRECISION  SS(3)
+       DOUBLE PRECISION  VALS(NMAX)
+       DOUBLE PRECISION  XI
+       DOUBLE PRECISION  JDEPOC
+  
+       INTEGER  I
+       INTEGER  LINE
+       DATA LINE/0/
+       INTEGER  NVS,NTARG,NCTR,NCOORD
+       INTEGER  NPT
+       DATA NPT/100/
+
+C      Write a fingerprint to the screen.
+
+       WRITE(*,*) ' JPL TEST-EPHEMERIS program. ' //
+     .            ' Last modified March 2013.'
+
+C      Print the ephemeris constants.
+
+       CALL  CONST (NAMS, VALS, SS, NVS)
+
+       JDEPOC = 2440400.5d0
+
+       WRITE (*,'(/3F14.2)') SS
+       
+       DO I=1,NVS
+         IF(NAMS(I) .EQ. 'JDEPOC')JDEPOC = VALS(I)
+         WRITE(6,'(A8,D24.16)')NAMS(I),VALS(I)
+       ENDDO
+
+C     Skip the file header comments.
+
+   1  READ(*,'(a3)')ALF3
+      IF(ALF3 .NE. 'EOT') GO TO 1
+
+      WRITE(*,*) 
+     . '  line -- jed --   t#   c#   x#   --- jpl value ---'//
+     . '   --- user value --    -- difference --'
+      WRITE(*,*) 
+
+C     Read a value from the test case; skip if not within the time-range
+C     of the present version of the ephemeris
+
+   2  READ(*,'(15X,D10.1,3I3,F30.20)',END=9)  
+     . ET,NTARG,NCTR,NCOORD,XI
+
+CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+
+C  NOTE : Over the years, different versions of PLEPH have had a fifth argument:
+C  sometimes, an error return statement number; sometimes, a logical denoting
+C  whether or not the requested date is covered by the ephemeris.  We apologize
+C  for this inconsistency; in this version, we use only the four necessary 
+C  arguments and do the testing outside of the subroutine.
+
+      IF(ET .LT. SS(1)) GO TO 2
+      IF(ET .GT. SS(2)) GO TO 2
+
+      CALL  PLEPH ( ET, NTARG, NCTR, R )
+
+CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+
+c     For testing purposes DEL is the computation of the difference in
+c       read values of the ephemeris converted from the export ascii files
+c       versus those printed form the original integration.
+c     The difference is checked for random parameters, one every 32 day interval.
+c     The agreement is considered okay if DEl is less that 1e-13.
+c     This corresponds to a few cm for body positions, and very small
+c     values for velocities, and angles and their rates.
+c       (A fractional test isn't suitable since sometimes the values will
+c        be near zero for particular components.)
+c     For lunar libration psi, NCOORD=15, the angle accumulates in time
+c     so precision is lost after several centuries. This is handled below
+c     by scaling DEL down for psi, by 100 radians per year from the reference epoch,
+c     as opposed to having different tolerances for different types of quantities.
+
+      DEL=DABS(R(NCOORD)-XI)
+
+      IF(NTARG .EQ. 15 .AND. NCOORD .EQ. 3)THEN
+        DEL = DEL/(1.D0+100.D0*ABS(ET-JDEPOC)/365.25d0)
+      ENDIF
+
+      LINE = LINE+1
+
+      IF ( MOD(LINE,npt) .EQ. 0 )  WRITE(*,200)
+     & LINE,ET,NTARG,NCTR,NCOORD,XI,R(NCOORD),DEL
+ 200  FORMAT(I6,F10.1,3I5,2F25.13,1E13.5)
+
+C  Print out WARNING if difference greater than tolerance.
+C
+      IF (DEL .GE. 1.D-13) WRITE(*,201) 
+     . LINE,ET,NTARG,NCTR,NCOORD,XI,R(NCOORD),DEL
+ 201  FORMAT(/ '*****  WARNING : next difference >= 1.D-13  *****'//
+     . I6,F10.1,3I3,2F25.13,1E13.5/' ')
+
+      GO TO 2
+
+   9  STOP
+      END
+
+C++++++++++++++++++++++++
+C
+      SUBROUTINE FSIZER1(NRECL,KSIZE,NRFILE,NAMFIL)
+C
+C++++++++++++++++++++++++
+C
+C   Version 1.0 uses the INQUIRE statement to find out the the record length 
+C   of the direct access file before opening it.  This procedure is non-standard, 
+C   but seems to work for VAX machines. 
+C
+C  THE SUBROUTINE ALSO SETS THE VALUES OF  NRECL, NRFILE, AND NAMFIL.
+
+C  *****************************************************************
+C  *****************************************************************
+C
+C  THE PARAMETERS NAMFIL, NRECL, AND NRFILE ARE TO BE SET BY THE USER
+C
+C  *****************************************************************
+
+C  NAMFIL IS THE EXTERNAL NAME OF THE BINARY EPHEMERIS FILE
+
+      CHARACTER*80  NAMFIL
+
+c      NAMFIL='JPLEPH'
+
+C  *****************************************************************
+
+C  NRECL=1 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN S.P. WORDS
+C  NRECL=4 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN BYTES
+C  (for a VAX, it is probably 1)
+C
+      NRECL= 
+
+C  *****************************************************************
+
+C  NRFILE IS THE INTERNAL UNIT NUMBER USED FOR THE EPHEMERIS FILE
+
+c      NRFILE=12
+
+C  *****************************************************************
+
+C   FIND THE RECORD SIZE USING THE INQUIRE STATEMENT  
+
+
+c      IRECSZ=0
+
+      INQUIRE(FILE=NAMFIL,RECL=IRECSZ)
+
+C IF 'INQUIRE' DOES NOT WORK, USUALLY IRECSZ WILL BE LEFT AT 0 
+
+      IF(IRECSZ .LE. 0) write(*,*)
+     . ' INQUIRE STATEMENT PROBABLY DID NOT WORK'
+
+      KSIZE=IRECSZ/NRECL
+
+      RETURN
+
+      END
+C++++++++++++++++++++++++
+C
+      SUBROUTINE FSIZER2(NRECL,KSIZE,NRFILE,NAMFIL)
+C
+C++++++++++++++++++++++++
+C  THIS SUBROUTINE OPENS THE FILE, 'NAMFIL', WITH A PHONY RECORD LENGTH, READS 
+C  THE FIRST RECORD, AND USES THE INFO TO COMPUTE KSIZE, THE NUMBER OF SINGLE 
+C  PRECISION WORDS IN A RECORD.  
+C
+C  THE SUBROUTINE ALSO SETS THE VALUES OF  NRECL, NRFILE, AND NAMFIL.
+
+      IMPLICIT DOUBLE PRECISION(A-H,O-Z)
+
+      SAVE
+
+      INTEGER OLDMAX
+      PARAMETER (OLDMAX = 400)
+      INTEGER NMAX
+      PARAMETER (NMAX = 1000)
+
+      CHARACTER*6 TTL(14,3),CNAM(NMAX)
+      CHARACTER*80 NAMFIL
+
+      DIMENSION SS(3)
+
+      INTEGER IPT(3,13)
+
+C  *****************************************************************
+C  *****************************************************************
+C
+C  THE PARAMETERS NRECL, NRFILE, AND NAMFIL ARE TO BE SET BY THE USER
+C
+C  *****************************************************************
+
+C  NRECL=1 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN S.P. WORDS
+C  NRECL=4 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN BYTES
+C  (for UNIX, it is probably 4)
+C
+      NRECL=
+
+C  NRFILE IS THE INTERNAL UNIT NUMBER USED FOR THE EPHEMERIS FILE
+
+      NRFILE=12
+
+C  NAMFIL IS THE EXTERNAL NAME OF THE BINARY EPHEMERIS FILE
+
+      NAMFIL='JPLEPH' 
+
+C  *****************************************************************
+C  *****************************************************************
+
+C  **  OPEN THE DIRECT-ACCESS FILE AND GET THE POINTERS IN ORDER TO 
+C  **  DETERMINE THE SIZE OF THE EPHEMERIS RECORD
+
+      MRECL=NRECL*1000
+
+        OPEN(NRFILE,
+     *       FILE=NAMFIL,
+     *       ACCESS='DIRECT',
+     *       FORM='UNFORMATTED',
+     *       RECL=MRECL,
+     *       STATUS='OLD')
+
+      READ(NRFILE,REC=1)TTL,(CNAM(K),K=1,OLDMAX),SS,NCON,AU,EMRAT,
+     & ((IPT(I,J),I=1,3),J=1,12),NUMDE,(IPT(I,13),I=1,3)
+
+      CLOSE(NRFILE)
+
+C  FIND THE NUMBER OF EPHEMERIS COEFFICIENTS FROM THE POINTERS
+
+      KMX = 0
+      KHI = 0
+
+      DO I = 1,13
+         IF (IPT(1,I) .GE. KMX) THEN
+            KMX = IPT(1,I)
+            KHI = I
+         ENDIF
+      ENDDO
+
+      ND = 3
+      IF (KHI .EQ. 12) ND=2
+
+      KSIZE = 2*(IPT(1,KHI)+ND*IPT(2,KHI)*IPT(3,KHI)-1)
+
+      RETURN
+
+      END
+C++++++++++++++++++++++++
+C
+      SUBROUTINE FSIZER3(NRECL,KSIZE,NRFILE,NAMFIL)
+C
+C++++++++++++++++++++++++
+C
+C  THE SUBROUTINE SETS THE VALUES OF  NRECL, KSIZE, NRFILE, AND NAMFIL.
+
+      SAVE
+
+      CHARACTER*80 NAMFIL
+
+C  *****************************************************************
+C  *****************************************************************
+C
+C  THE PARAMETERS NRECL, NRFILE, AND NAMFIL ARE TO BE SET BY THE USER
+
+C  *****************************************************************
+
+C  NRECL=1 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN S.P. WORDS
+C  NRECL=4 IF "RECL" IN THE OPEN STATEMENT IS THE RECORD LENGTH IN BYTES
+
+       NRECL=
+
+C  *****************************************************************
+
+C  NRFILE IS THE INTERNAL UNIT NUMBER USED FOR THE EPHEMERIS FILE (DEFAULT: 12)
+
+      NRFILE=12
+
+C  *****************************************************************
+
+C  NAMFIL IS THE EXTERNAL NAME OF THE BINARY EPHEMERIS FILE
+
+      NAMFIL='JPLEPH'
+
+C  *****************************************************************
+
+C  KSIZE must be set by the user according to the ephemeris to be read
+
+C  For  de200, set KSIZE to 1652
+C  For  de405, set KSIZE to 2036
+C  For  de406, set KSIZE to 1456
+C  For  de414, set KSIZE to 2036
+C  For  de418, set KSIZE to 2036
+C  For  de421, set KSIZE to 2036
+C  For  de422, set KSIZE to 2036
+C  For  de423, set KSIZE to 2036
+C  For  de424, set KSIZE to 2036
+C  For  de430, set KSIZE to 2036
+
+      KSIZE = 
+
+C  *******************************************************************
+
+      RETURN
+
+      END
+C++++++++++++++++++++++++++
+C
+      SUBROUTINE PLEPH ( ET, NTARG, NCENT, RRD )
+C
+C++++++++++++++++++++++++++
+C  NOTE : Over the years, different versions of PLEPH have had a fifth argument:
+C  sometimes, an error return statement number; sometimes, a logical denoting
+C  whether or not the requested date is covered by the ephemeris.  We apologize
+C  for this inconsistency; in this present version, we use only the four necessary 
+C  arguments and do the testing outside of the subroutine.
+C
+C     THIS SUBROUTINE READS THE JPL PLANETARY EPHEMERIS
+C     AND GIVES THE POSITION AND VELOCITY OF THE POINT 'NTARG'
+C     WITH RESPECT TO 'NCENT'.
+C
+C     CALLING SEQUENCE PARAMETERS:
+C
+C       ET = D.P. JULIAN EPHEMERIS DATE AT WHICH INTERPOLATION
+C            IS WANTED.
+C
+C       ** NOTE THE ENTRY DPLEPH FOR A DOUBLY-DIMENSIONED TIME **
+C          THE REASON FOR THIS OPTION IS DISCUSSED IN THE 
+C          SUBROUTINE STATE
+C
+C     NTARG = INTEGER NUMBER OF 'TARGET' POINT.
+C
+C     NCENT = INTEGER NUMBER OF CENTER POINT.
+C
+C            THE NUMBERING CONVENTION FOR 'NTARG' AND 'NCENT' IS:
+C
+C                1 = MERCURY           8 = NEPTUNE
+C                2 = VENUS             9 = PLUTO
+C                3 = EARTH            10 = MOON
+C                4 = MARS             11 = SUN
+C                5 = JUPITER          12 = SOLAR-SYSTEM BARYCENTER
+C                6 = SATURN           13 = EARTH-MOON BARYCENTER
+C                7 = URANUS           14 = NUTATIONS (LONGITUDE AND OBLIQ)
+C                            15 = LIBRATIONS, IF ON EPH FILE
+C
+C             (IF NUTATIONS ARE WANTED, SET NTARG = 14. FOR LIBRATIONS,
+C              SET NTARG = 15. SET NCENT=0.)
+C
+C      RRD = OUTPUT 6-WORD D.P. ARRAY CONTAINING POSITION AND VELOCITY
+C            OF POINT 'NTARG' RELATIVE TO 'NCENT'. THE UNITS ARE AU AND
+C            AU/DAY. FOR LIBRATIONS THE UNITS ARE RADIANS AND RADIANS
+C            PER DAY. IN THE CASE OF NUTATIONS THE FIRST FOUR WORDS OF
+C            RRD WILL BE SET TO NUTATIONS AND RATES, HAVING UNITS OF
+C            RADIANS AND RADIANS/DAY.
+C
+C            The option is available to have the units in km and km/sec.
+C            For this, set km=.true. in the STCOMX common block.
+C
+
+      IMPLICIT DOUBLE PRECISION (A-H,O-Z)
+
+      INTEGER NMAX
+      PARAMETER (NMAX = 1000)
+
+      DIMENSION RRD(6),ET2Z(2),ET2(2),PV(6,13)
+      DIMENSION PVST(6,11),PNUT(4)
+      DIMENSION SS(3),CVAL(NMAX),PVSUN(6),ZIPS(2)
+      DATA ZIPS/2*0.d0/
+
+      LOGICAL BSAVE,KM,BARY
+      LOGICAL FIRST
+      DATA FIRST/.TRUE./
+
+      INTEGER LIST(12),IPT(39),DENUM
+
+      COMMON/EPHHDR/CVAL,SS,AU,EMRAT,DENUM,NCON,IPT
+
+      COMMON/STCOMX/KM,BARY,PVSUN
+
+C     INITIALIZE ET2 FOR 'STATE' AND SET UP COMPONENT COUNT
+C
+      ET2(1)=ET
+      ET2(2)=0.D0
+      GO TO 11
+
+C     ENTRY POINT 'DPLEPH' FOR DOUBLY-DIMENSIONED TIME ARGUMENT 
+C          (SEE THE DISCUSSION IN THE SUBROUTINE STATE)
+
+      ENTRY DPLEPH(ET2Z,NTARG,NCENT,RRD)
+
+      ET2(1)=ET2Z(1)
+      ET2(2)=ET2Z(2)
+
+  11  IF(FIRST) CALL STATE(ZIPS,LIST,PVST,PNUT)
+      FIRST=.FALSE.
+
+  96  IF(NTARG .EQ. NCENT) RETURN
+
+      DO I=1,12
+        LIST(I)=0
+      ENDDO
+
+C     CHECK FOR NUTATION CALL
+
+      IF(NTARG.NE.14) GO TO 97
+        IF(IPT(35).GT.0) THEN
+          LIST(11)=2
+          CALL STATE(ET2,LIST,PVST,PNUT)
+          DO I=1,4
+            RRD(I)=PNUT(I)
+          ENDDO
+          RRD(5) = 0.d0
+          RRD(6) = 0.d0
+          RETURN
+        ELSE
+          DO I=1,4
+            RRD(I)=0.d0
+          ENDDO
+          WRITE(6,297)
+  297     FORMAT(' *****  NO NUTATIONS ON THE EPHEMERIS FILE  *****')
+          STOP
+        ENDIF
+
+C     CHECK FOR LIBRATIONS
+
+  97  CONTINUE
+      DO I=1,6
+        RRD(I)=0.d0
+      ENDDO
+
+      IF(NTARG.NE.15) GO TO 98
+        IF(IPT(38).GT.0) THEN
+          LIST(12)=2
+          CALL STATE(ET2,LIST,PVST,PNUT)
+          DO I=1,6
+            RRD(I)=PVST(I,11)
+          ENDDO
+          RETURN
+        ELSE
+          WRITE(6,298)
+  298     FORMAT(' *****  NO LIBRATIONS ON THE EPHEMERIS FILE  *****')
+          STOP
+        ENDIF
+
+C       FORCE BARYCENTRIC OUTPUT BY 'STATE'
+
+  98  BSAVE=BARY
+      BARY=.TRUE.
+
+C       SET UP PROPER ENTRIES IN 'LIST' ARRAY FOR STATE CALL
+
+      DO I=1,2
+        K=NTARG
+        IF(I .EQ. 2) K=NCENT
+        IF(K .LE. 10) LIST(K)=2
+        IF(K .EQ. 10) LIST(3)=2
+        IF(K .EQ. 3) LIST(10)=2
+        IF(K .EQ. 13) LIST(3)=2
+      ENDDO
+
+C       MAKE CALL TO STATE
+
+      CALL STATE(ET2,LIST,PVST,PNUT)
+
+      DO I=1,10
+        DO J = 1,6
+          PV(J,I) = PVST(J,I)
+        ENDDO
+      ENDDO
+
+      IF(NTARG .EQ. 11 .OR. NCENT .EQ. 11) THEN
+      DO I=1,6
+        PV(I,11)=PVSUN(I)
+      ENDDO
+      ENDIF
+
+      IF(NTARG .EQ. 12 .OR. NCENT .EQ. 12) THEN
+        DO I=1,6
+          PV(I,12)=0.D0
+        ENDDO
+      ENDIF
+
+      IF(NTARG .EQ. 13 .OR. NCENT .EQ. 13) THEN
+        DO I=1,6
+          PV(I,13) = PVST(I,3)
+        ENDDO
+      ENDIF
+
+      IF(NTARG*NCENT .EQ. 30 .AND. NTARG+NCENT .EQ. 13) THEN
+        DO I=1,6
+          PV(I,3)=0.D0
+        ENDDO
+        GO TO 99
+      ENDIF
+
+      IF(LIST(3) .EQ. 2) THEN
+        DO I=1,6
+          PV(I,3)=PVST(I,3)-PVST(I,10)/(1.D0+EMRAT)
+        ENDDO
+      ENDIF
+
+      IF(LIST(10) .EQ. 2) THEN
+        DO I=1,6
+          PV(I,10) = PV(I,3)+PVST(I,10)
+        ENDDO
+      ENDIF
+
+  99  DO I=1,6
+        RRD(I)=PV(I,NTARG)-PV(I,NCENT)
+      ENDDO
+
+      BARY=BSAVE
+
+      RETURN
+      END
+C+++++++++++++++++++++++++++++++++
+C
+      SUBROUTINE INTERP(BUF,T,NCF,NCM,NA,IFL,PV)
+C
+C+++++++++++++++++++++++++++++++++
+C
+C     THIS SUBROUTINE DIFFERENTIATES AND INTERPOLATES A
+C     SET OF CHEBYSHEV COEFFICIENTS TO GIVE POSITION AND VELOCITY
+C
+C     CALLING SEQUENCE PARAMETERS:
+C
+C       INPUT:
+C
+C         BUF   1ST LOCATION OF ARRAY OF D.P. CHEBYSHEV COEFFICIENTS OF POSITION
+C
+C           T   T(1) IS DP FRACTIONAL TIME IN INTERVAL COVERED BY
+C               COEFFICIENTS AT WHICH INTERPOLATION IS WANTED
+C               (0 .LE. T(1) .LE. 1).  T(2) IS DP LENGTH OF WHOLE
+C               INTERVAL IN INPUT TIME UNITS.
+C
+C         NCF   # OF COEFFICIENTS PER COMPONENT
+C
+C         NCM   # OF COMPONENTS PER SET OF COEFFICIENTS
+C
+C          NA   # OF SETS OF COEFFICIENTS IN FULL ARRAY
+C               (I.E., # OF SUB-INTERVALS IN FULL INTERVAL)
+C
+C          IFL  INTEGER FLAG: =1 FOR POSITIONS ONLY
+C                             =2 FOR POS AND VEL
+C
+C
+C       OUTPUT:
+C
+C         PV   INTERPOLATED QUANTITIES REQUESTED.  DIMENSION
+C               EXPECTED IS PV(NCM,IFL), DP.
+C
+C
+      IMPLICIT DOUBLE PRECISION (A-H,O-Z)
+C
+      SAVE
+C
+      DOUBLE PRECISION BUF(NCF,NCM,*),T(2),PV(NCM,*),PC(18),VC(18)
+
+C
+      DATA NP/2/
+      DATA NV/3/
+      DATA TWOT/0.D0/
+      DATA PC(1),PC(2)/1.D0,0.D0/
+      DATA VC(2)/1.D0/
+C
+C       ENTRY POINT. GET CORRECT SUB-INTERVAL NUMBER FOR THIS SET
+C       OF COEFFICIENTS AND THEN GET NORMALIZED CHEBYSHEV TIME
+C       WITHIN THAT SUBINTERVAL.
+C
+      DNA=DBLE(NA)
+      DT1=DINT(T(1))
+      TEMP=DNA*T(1)
+      L=IDINT(TEMP-DT1)+1
+
+C         TC IS THE NORMALIZED CHEBYSHEV TIME (-1 .LE. TC .LE. 1)
+
+      TC=2.D0*(DMOD(TEMP,1.D0)+DT1)-1.D0
+
+C       CHECK TO SEE WHETHER CHEBYSHEV TIME HAS CHANGED,
+C       AND COMPUTE NEW POLYNOMIAL VALUES IF IT HAS.
+C       (THE ELEMENT PC(2) IS THE VALUE OF T1(TC) AND HENCE
+C       CONTAINS THE VALUE OF TC ON THE PREVIOUS CALL.)
+
+      IF(TC.NE.PC(2)) THEN
+        NP=2
+        NV=3
+        PC(2)=TC
+        TWOT=TC+TC
+      ENDIF
+C
+C       BE SURE THAT AT LEAST 'NCF' POLYNOMIALS HAVE BEEN EVALUATED
+C       AND ARE STORED IN THE ARRAY 'PC'.
+C
+      IF(NP.LT.NCF) THEN
+        DO 1 I=NP+1,NCF
+        PC(I)=TWOT*PC(I-1)-PC(I-2)
+    1   CONTINUE
+        NP=NCF
+      ENDIF
+C
+C       INTERPOLATE TO GET POSITION FOR EACH COMPONENT
+C
+      DO 2 I=1,NCM
+      PV(I,1)=0.D0
+      DO 3 J=NCF,1,-1
+      PV(I,1)=PV(I,1)+PC(J)*BUF(J,I,L)
+    3 CONTINUE
+    2 CONTINUE
+      IF(IFL.LE.1) RETURN
+C
+C       IF VELOCITY INTERPOLATION IS WANTED, BE SURE ENOUGH
+C       DERIVATIVE POLYNOMIALS HAVE BEEN GENERATED AND STORED.
+C
+      VFAC=(DNA+DNA)/T(2)
+      VC(3)=TWOT+TWOT
+      IF(NV.LT.NCF) THEN
+        DO 4 I=NV+1,NCF
+        VC(I)=TWOT*VC(I-1)+PC(I-1)+PC(I-1)-VC(I-2)
+    4   CONTINUE
+        NV=NCF
+      ENDIF
+C
+C       INTERPOLATE TO GET VELOCITY FOR EACH COMPONENT
+C
+      DO 5 I=1,NCM
+      PV(I,2)=0.D0
+      DO 6 J=NCF,2,-1
+      PV(I,2)=PV(I,2)+VC(J)*BUF(J,I,L)
+    6 CONTINUE
+      PV(I,2)=PV(I,2)*VFAC
+    5 CONTINUE
+C
+      RETURN
+C
+      END
+
+C+++++++++++++++++++++++++
+C
+      SUBROUTINE SPLIT(TT,FR)
+C
+C+++++++++++++++++++++++++
+C
+C     THIS SUBROUTINE BREAKS A D.P. NUMBER INTO A D.P. INTEGER
+C     AND A D.P. FRACTIONAL PART.
+C
+C     CALLING SEQUENCE PARAMETERS:
+C
+C       TT = D.P. INPUT NUMBER
+C
+C       FR = D.P. 2-WORD OUTPUT ARRAY.
+C            FR(1) CONTAINS INTEGER PART
+C            FR(2) CONTAINS FRACTIONAL PART
+C
+C            FOR NEGATIVE INPUT NUMBERS, FR(1) CONTAINS THE NEXT
+C            MORE NEGATIVE INTEGER; FR(2) CONTAINS A POSITIVE FRACTION.
+C
+C       CALLING SEQUENCE DECLARATIONS
+C
+      IMPLICIT DOUBLE PRECISION (A-H,O-Z)
+
+      DIMENSION FR(2)
+
+C       MAIN ENTRY -- GET INTEGER AND FRACTIONAL PARTS
+
+      FR(1)=DINT(TT)
+      FR(2)=TT-FR(1)
+
+      IF(TT.GE.0.D0 .OR. FR(2).EQ.0.D0) RETURN
+
+C       MAKE ADJUSTMENTS FOR NEGATIVE INPUT NUMBER
+
+      FR(1)=FR(1)-1.D0
+      FR(2)=FR(2)+1.D0
+
+      RETURN
+
+      END
+
+
+C++++++++++++++++++++++++++++++++
+C
+      SUBROUTINE STATE(ET2,LIST,PV,PNUT)
+C
+C++++++++++++++++++++++++++++++++
+C
+C THIS SUBROUTINE READS AND INTERPOLATES THE JPL PLANETARY EPHEMERIS FILE
+C
+C     CALLING SEQUENCE PARAMETERS:
+C
+C     INPUT:
+C
+C         ET2   DP 2-WORD JULIAN EPHEMERIS EPOCH AT WHICH INTERPOLATION
+C               IS WANTED.  ANY COMBINATION OF ET2(1)+ET2(2) WHICH FALLS
+C               WITHIN THE TIME SPAN ON THE FILE IS A PERMISSIBLE EPOCH.
+C
+C                A. FOR EASE IN PROGRAMMING, THE USER MAY PUT THE
+C                   ENTIRE EPOCH IN ET2(1) AND SET ET2(2)=0.
+C
+C                B. FOR MAXIMUM INTERPOLATION ACCURACY, SET ET2(1) =
+C                   THE MOST RECENT MIDNIGHT AT OR BEFORE INTERPOLATION
+C                   EPOCH AND SET ET2(2) = FRACTIONAL PART OF A DAY
+C                   ELAPSED BETWEEN ET2(1) AND EPOCH.
+C
+C                C. AS AN ALTERNATIVE, IT MAY PROVE CONVENIENT TO SET
+C                   ET2(1) = SOME FIXED EPOCH, SUCH AS START OF INTEGRATION,
+C                   AND ET2(2) = ELAPSED INTERVAL BETWEEN THEN AND EPOCH.
+C
+C        LIST   12-WORD INTEGER ARRAY SPECIFYING WHAT INTERPOLATION
+C               IS WANTED FOR EACH OF THE BODIES ON THE FILE.
+C
+C                         LIST(I)=0, NO INTERPOLATION FOR BODY I
+C                                =1, POSITION ONLY
+C                                =2, POSITION AND VELOCITY
+C
+C               THE DESIGNATION OF THE ASTRONOMICAL BODIES BY I IS:
+C
+C                         I = 1: MERCURY
+C                           = 2: VENUS
+C                           = 3: EARTH-MOON BARYCENTER
+C                           = 4: MARS
+C                           = 5: JUPITER
+C                           = 6: SATURN
+C                           = 7: URANUS
+C                           = 8: NEPTUNE
+C                           = 9: PLUTO
+C                           =10: GEOCENTRIC MOON
+C                           =11: NUTATIONS IN LONGITUDE AND OBLIQUITY
+C                           =12: LUNAR LIBRATIONS (IF ON FILE)
+C
+C     OUTPUT:
+C
+C          PV   DP 6 X 11 ARRAY THAT WILL CONTAIN REQUESTED INTERPOLATED
+C               QUANTITIES (OTHER THAN NUTATION, STOERD IN PNUT).  
+C               THE BODY SPECIFIED BY LIST(I) WILL HAVE ITS
+C               STATE IN THE ARRAY STARTING AT PV(1,I).  
+C               (ON ANY GIVEN CALL, ONLY THOSE WORDS IN 'PV' WHICH ARE 
+C                AFFECTED BY THE  FIRST 10 'LIST' ENTRIES, AND BY LIST(12)
+C                IF LIBRATIONS ARE ON THE FILE, ARE SET.  
+C                THE REST OF THE 'PV' ARRAYIS UNTOUCHED.)  
+C               THE ORDER OF COMPONENTS STARTING IN PV(1,I) IS: X,Y,Z,DX,DY,DZ.
+C
+C               ALL OUTPUT VECTORS ARE REFERENCED TO THE EARTH MEAN
+C               EQUATOR AND EQUINOX OF J2000 IF THE DE NUMBER IS 200 OR
+C               GREATER; OF B1950 IF THE DE NUMBER IS LESS THAN 200. 
+C
+C               THE MOON STATE IS ALWAYS GEOCENTRIC; THE OTHER NINE STATES 
+C               ARE EITHER HELIOCENTRIC OR SOLAR-SYSTEM BARYCENTRIC, 
+C               DEPENDING ON THE SETTING OF COMMON FLAGS (SEE BELOW).
+C
+C               LUNAR LIBRATIONS, IF ON FILE, ARE PUT INTO PV(K,11) IF
+C               LIST(12) IS 1 OR 2.
+C
+C         NUT   DP 4-WORD ARRAY THAT WILL CONTAIN NUTATIONS AND RATES,
+C               DEPENDING ON THE SETTING OF LIST(11).  THE ORDER OF
+C               QUANTITIES IN NUT IS:
+C
+C                        D PSI  (NUTATION IN LONGITUDE)
+C                        D EPSILON (NUTATION IN OBLIQUITY)
+C                        D PSI DOT
+C                        D EPSILON DOT
+C
+C           *   STATEMENT # FOR ERROR RETURN, IN CASE OF EPOCH OUT OF
+C               RANGE OR I/O ERRORS.
+C
+C     COMMON AREA STCOMX:
+C
+C          KM   LOGICAL FLAG DEFINING PHYSICAL UNITS OF THE OUTPUT
+C               STATES. KM = .TRUE., KM AND KM/SEC
+C                          = .FALSE., AU AND AU/DAY
+C               DEFAULT VALUE = .FALSE.  (KM DETERMINES TIME UNIT
+C               FOR NUTATIONS AND LIBRATIONS.  ANGLE UNIT IS ALWAYS RADIANS.)
+C
+C        BARY   LOGICAL FLAG DEFINING OUTPUT CENTER.
+C               ONLY THE 9 PLANETS ARE AFFECTED.
+C                        BARY = .TRUE. =\ CENTER IS SOLAR-SYSTEM BARYCENTER
+C                             = .FALSE. =\ CENTER IS SUN
+C               DEFAULT VALUE = .FALSE.
+C
+C       PVSUN   DP 6-WORD ARRAY CONTAINING THE BARYCENTRIC POSITION AND
+C               VELOCITY OF THE SUN.
+C
+C
+      IMPLICIT DOUBLE PRECISION (A-H,O-Z)
+
+      SAVE
+
+      INTEGER OLDMAX
+      PARAMETER ( OLDMAX = 400)
+      INTEGER NMAX
+      PARAMETER ( NMAX = 1000)
+
+      DIMENSION ET2(2),PV(6,11),PNUT(4),T(2),PJD(4),BUF(1500),
+     . SS(3),CVAL(NMAX),PVSUN(6)
+
+      INTEGER LIST(12),IPT(3,13)
+
+      LOGICAL FIRST
+      DATA FIRST/.TRUE./
+
+      CHARACTER*6 TTL(14,3),CNAM(NMAX)
+      CHARACTER*80 NAMFIL
+
+      LOGICAL KM,BARY
+
+      COMMON/EPHHDR/CVAL,SS,AU,EMRAT,NUMDE,NCON,IPT
+      COMMON/CHRHDR/CNAM,TTL
+      COMMON/STCOMX/KM,BARY,PVSUN
+
+C
+C       ENTRY POINT - 1ST TIME IN, GET POINTER DATA, ETC., FROM EPH FILE
+C
+      IF(FIRST) THEN
+        FIRST=.FALSE.
+
+C ************************************************************************
+C ************************************************************************
+
+C THE USER MUST SELECT ONE OF THE FOLLOWING BY DELETING THE 'C' IN COLUMN 1
+
+C ************************************************************************
+
+C        CALL FSIZER1(NRECL,KSIZE,NRFILE,NAMFIL)
+C        CALL FSIZER2(NRECL,KSIZE,NRFILE,NAMFIL)
+C        CALL FSIZER3(NRECL,KSIZE,NRFILE,NAMFIL)
+
+      IF(NRECL .EQ. 0) WRITE(*,*)'  ***** FSIZER IS NOT WORKING *****'
+
+C ************************************************************************
+C ************************************************************************
+
+      IRECSZ=NRECL*KSIZE
+      NCOEFFS=KSIZE/2
+
+        OPEN(NRFILE,
+     *       FILE=NAMFIL,
+     *       ACCESS='DIRECT',
+     *       FORM='UNFORMATTED',
+     *       RECL=IRECSZ,
+     *       STATUS='OLD')
+
+      READ(NRFILE,REC=1)TTL,(CNAM(K),K=1,OLDMAX),SS,NCON,AU,EMRAT,
+     & ((IPT(I,J),I=1,3),J=1,12),NUMDE,(IPT(I,13),I=1,3)
+     & ,(CNAM(L),L=OLDMAX+1,NCON)
+
+      IF(NCON .LE. OLDMAX)THEN
+        READ(NRFILE,REC=2)(CVAL(I),I=1,OLDMAX)
+      ELSE
+        READ(NRFILE,REC=2)(CVAL(I),I=1,NCON)
+      ENDIF
+
+      NRL=0
+
+      ENDIF
+
+C       ********** MAIN ENTRY POINT **********
+
+      IF(ET2(1) .EQ. 0.D0) RETURN
+
+      S=ET2(1)-.5D0
+      CALL SPLIT(S,PJD(1))
+      CALL SPLIT(ET2(2),PJD(3))
+      PJD(1)=PJD(1)+PJD(3)+.5D0
+      PJD(2)=PJD(2)+PJD(4)
+      CALL SPLIT(PJD(2),PJD(3))
+      PJD(1)=PJD(1)+PJD(3)
+
+C       ERROR RETURN FOR EPOCH OUT OF RANGE
+
+      IF(PJD(1)+PJD(4).LT.SS(1) .OR. PJD(1)+PJD(4).GT.SS(2)) GO TO 98
+
+C       CALCULATE RECORD # AND RELATIVE TIME IN INTERVAL
+
+      NR=IDINT((PJD(1)-SS(1))/SS(3))+3
+      IF(PJD(1).EQ.SS(2)) NR=NR-1
+
+        tmp1 = DBLE(NR-3)*SS(3) + SS(1)
+        tmp2 = PJD(1) - tmp1
+        T(1) = (tmp2 + PJD(4))/SS(3)
+
+C       READ CORRECT RECORD IF NOT IN CORE
+
+      IF(NR.NE.NRL) THEN
+        NRL=NR
+        READ(NRFILE,REC=NR,ERR=99)(BUF(K),K=1,NCOEFFS)
+      ENDIF
+
+      IF(KM) THEN
+      T(2)=SS(3)*86400.D0
+      AUFAC=1.D0
+      ELSE
+      T(2)=SS(3)
+      AUFAC=1.D0/AU
+      ENDIF
+
+C   INTERPOLATE SSBARY SUN
+
+      CALL INTERP(BUF(IPT(1,11)),T,IPT(2,11),3,IPT(3,11),2,PVSUN)
+
+      DO I=1,6
+      PVSUN(I)=PVSUN(I)*AUFAC
+      ENDDO
+
+C   CHECK AND INTERPOLATE WHICHEVER BODIES ARE REQUESTED
+
+      DO 4 I=1,10
+      IF(LIST(I).EQ.0) GO TO 4
+
+      CALL INTERP(BUF(IPT(1,I)),T,IPT(2,I),3,IPT(3,I),
+     & LIST(I),PV(1,I))
+
+      DO J=1,6
+       IF(I.LE.9 .AND. .NOT.BARY) THEN
+       PV(J,I)=PV(J,I)*AUFAC-PVSUN(J)
+       ELSE
+       PV(J,I)=PV(J,I)*AUFAC
+       ENDIF
+      ENDDO
+
+   4  CONTINUE
+
+C       DO NUTATIONS IF REQUESTED (AND IF ON FILE)
+
+      IF(LIST(11).GT.0 .AND. IPT(2,12).GT.0)
+     * CALL INTERP(BUF(IPT(1,12)),T,IPT(2,12),2,IPT(3,12),
+     * LIST(11),PNUT)
+
+C       GET LIBRATIONS IF REQUESTED (AND IF ON FILE)
+
+      IF(LIST(12).GT.0 .AND. IPT(2,13).GT.0)
+     * CALL INTERP(BUF(IPT(1,13)),T,IPT(2,13),3,IPT(3,13),
+     * LIST(12),PV(1,11))
+
+      RETURN
+
+  98  WRITE(*,198)ET2(1)+ET2(2),SS(1),SS(2)
+ 198  FORMAT(' ***  Requested JED,',f12.2,
+     * ' not within ephemeris limits,',2f12.2,'  ***')
+
+      STOP
+
+   99 WRITE(*,'(2F12.2,A80)')ET2,'ERROR RETURN IN STATE'
+
+      STOP
+
+      END
+C+++++++++++++++++++++++++++++
+C
+      SUBROUTINE CONST(NAM,VAL,SSS,N)
+C
+C+++++++++++++++++++++++++++++
+C
+C     THIS ENTRY OBTAINS THE CONSTANTS FROM THE EPHEMERIS FILE
+C
+C     CALLING SEQEUNCE PARAMETERS (ALL OUTPUT):
+C
+C       NAM = CHARACTER*6 ARRAY OF CONSTANT NAMES
+C
+C       VAL = D.P. ARRAY OF VALUES OF CONSTANTS
+C
+C       SSS = D.P. JD START, JD STOP, STEP OF EPHEMERIS
+C
+C         N = INTEGER NUMBER OF ENTRIES IN 'NAM' AND 'VAL' ARRAYS
+C
+      IMPLICIT DOUBLE PRECISION (A-H,O-Z)
+
+      SAVE
+
+      INTEGER NMAX
+      PARAMETER (NMAX = 1000)
+
+      CHARACTER*6 NAM(*),TTL(14,3),CNAM(NMAX)
+
+      DOUBLE PRECISION VAL(*),SSS(3),SS(3),CVAL(NMAX),ZIPS(2)
+      DOUBLE PRECISION PVST(6,11),PNUT(4)
+      DATA ZIPS/2*0.d0/
+
+      INTEGER IPT(3,13),DENUM,LIST(12)
+      logical first
+      data first/.true./
+
+      COMMON/EPHHDR/CVAL,SS,AU,EMRAT,DENUM,NCON,IPT
+      COMMON/CHRHDR/CNAM,TTL
+
+C  CALL STATE TO INITIALIZE THE EPHEMERIS AND READ IN THE CONSTANTS
+
+      IF(FIRST) CALL STATE(ZIPS,LIST,PVST,PNUT)
+      first=.false.
+
+      N=NCON
+
+      DO I=1,3
+        SSS(I)=SS(I)
+      ENDDO
+
+      DO I=1,N
+        NAM(I)=CNAM(I)
+        VAL(I)=CVAL(I)
+      ENDDO
+
+      RETURN
+
+      END

--- a/fortran/testeph1.f
+++ b/fortran/testeph1.f
@@ -1,0 +1,1474 @@
+      program TESTEPH
+C
+C    *****    JPL Planetary and Lunar Ephemerides read and test   *****
+C
+C                    Version : 15 March 2014
+C
+C     ---------------
+C  
+C     TESTEPH tests the JPL ephemeris reading and interpolating routine using
+C     test printouts computed from the original ephemeris.
+C
+C     TESTEPH contains the reading and interpolating subroutines that are of 
+C     eventual interest to the user.  Once TESTEPH is working correctly, the 
+C     user can extract those subroutines.
+C
+C     The user must supply "testpo.XXX" to TESTEPH, via standard input.  
+C     "testpo.XXX is the specially formatted text file that contains 
+C     the test cases for the ephemeris, DEXXX.
+C     e.g., on unix, type the command line;
+C
+C                          cat testpo.xxx | testeph.e
+C
+C     After the initial identifying text which is concluded by an "EOT" in
+C     columns 1-3, the testpo.xxx file contains the following quantities:
+C
+C         JPL Ephemeris Number
+C         Coordinate time:  TDB expressed as year:month:day
+C         Coordinate time:  TDB, expressed as Julian Date
+C         Target number:     1 - Mercury
+C                            2 - Venus 
+C                            3 - Earth (geocenter)
+C                            4 - Mars (system barycenter)
+C                            5 - Jupiter (system barycenter)
+C                            6 - Saturn (system barycenter)
+C                            7 - Uranus (system barycenter)
+C                            8 - Neptune (system barycenter)
+C                            9 - Pluto (system barycenter)
+C                           10 - Moon
+C                           11 - Sun
+C                           12 - Solar System Barycenter
+C                           13 - Earth-Moon Barycenter
+C                           14 - 1980 IAU nutation angles
+C                           15 - Lunar libration (Euler) angles
+C                           16 - Lunar angular velocity
+C                           17 - TT-TDB (at geocenter)
+C
+C         Center number:    [same codes as target number]
+C
+C         Coordinate:       [1-x, 2-y, 3-z, 4-dx/dt, 
+C                            5-dy/dt, 6-dz/dt] for bodies
+C                           [1-longitude, 2-obliquity, 
+C                            3-long. rate, 4-oblq. rate] for nutation
+C                           [1-phi, 2-theta,3-psi,
+C                            4-dpsi/dt,5-dtheta/dt,6-dpsi/dt] for libration
+C                           [1-omegax,2-omega-y,3-omega-z, 
+C                            4-6 rates] for lunar Euler angle rates
+C                           [1-TT-TDB, 2-rate] for TT-TDB.
+C
+C         Units:            Bodies: [au, au/day]
+C                           Nutation angles: [radians, radians/day] 
+C                           Libration angles: [radians, radians/day] 
+C                           Euler angle rates: [radians/day, radians/day**2]
+C                           TT-TDB: [seconds, seconds/day]
+C
+C     Note that the body positions are stored in units of km and km/s.
+C     By default these are scaled by the value of the astronomical unit
+C     read from the header of the ephemeris file to units of au and au/day.
+C     The testpo.xx print out is in units of au and au/day.
+C     The users of the PLEPH subroutine can choose other units for body
+C     position and velocity by first calling PL_UNITS with the desired inputs.
+C
+C     For each test case input, TESTEPH
+C
+C         - computes the corresponding state from data contained 
+C           in the binary ephemeris file,
+C
+C         - compares the data read with the value from the testpo.xxx file,
+C
+C         - writes an error message if the difference between
+C           any of the state components is greater than 10**(-13).
+C
+C         - writes state and difference information for every 100th
+C           test case processed.
+C
+C      This program is written in standard Fortran-77.  
+C
+C      HOWEVER, there are two parts which are compiler dependent; both have
+C      to do with opening and reading a direct-access file.  They are dealt
+C      with in the subroutine FSIZERi, i=1,3.  (There are three versions of 
+C      this subroutine.
+C
+C      1) The parameter RECL in the OPEN statement is the number of units per 
+C         record.  For some compilers, it is given in bytes; 
+C         in some, it is given in single precision words.  
+C         In the subroutine FSIZER of TESTEPH, 
+C         the  parameter NRECL must  be set to 4 if RECL is given in bytes; 
+C         NRECL must be set to 1 if RECL is given in words.  
+C         (If in doubt, use 4 for UNIX; 1 for VAX)
+C
+C      2) Also for the OPEN statement, the program needs to know 
+C         the exact value of RECL (number of single precision words 
+C         times NRECL).  Since this varies from one JPL ephemeris to another, 
+C         RECL must be determined somehow and given to the OPEN statement.  
+C         There are three methods, depending upon the compiler.  
+C         We have included three versions of the subroutine  FSIZER, 
+C         one for each method.
+C
+C         a)  Use the INQUIRE statement to find the length of the records 
+C             automatically before opening the file.  This works for VAX's; 
+C             not in UNIX.
+C
+C         b)  Open the file with an arbitrary value of RECL, 
+C             read the first record, and use the information on that record 
+C             to determine the exact value of RECL.  
+C             Then, close the file and re-open it with the exact value.
+C             This seems to work for UNIX compilers as long as 
+C             the initial value of RECL is less than the exact value 
+C             but large enough to get the required information from the file.
+C             (For some compilers, this doesn't work since you can open a file
+C              only with the exact value of RECL.)
+C
+C         c)  Hardwire the value of RECL.
+C                For  de200, RECL = NRECL * 1652
+C                For  de405, RECL = NRECL * 2036
+C                For  de406, RECL = NRECL * 1456
+C                For  de414 through de429,  RECL = NRECL * 2036
+C                For  de430 & de431, without TT-TDB; RECL = NRECL * 2036
+C                                    with    TT-TDB; RECL = NRECL * 1964
+C
+C
+C $ Disclaimer
+C
+C     THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE
+C     CALIFORNIA INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S.
+C     GOVERNMENT CONTRACT WITH THE NATIONAL AERONAUTICS AND SPACE
+C     ADMINISTRATION (NASA). THE SOFTWARE IS TECHNOLOGY AND SOFTWARE
+C     PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS AND IS PROVIDED "AS-IS"
+C     TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND, INCLUDING ANY
+C     WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR A
+C     PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC
+C     SECTIONS 2312-2313) OR FOR ANY PURPOSE WHATSOEVER, FOR THE
+C     SOFTWARE AND RELATED MATERIALS, HOWEVER USED.
+C
+C     IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA
+C     BE LIABLE FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT
+C     LIMITED TO, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+C     INCLUDING ECONOMIC DAMAGE OR INJURY TO PROPERTY AND LOST PROFITS,
+C     REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE ADVISED, HAVE
+C     REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
+C
+C     RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF
+C     THE SOFTWARE AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY
+C     CALTECH AND NASA FOR ALL THIRD-PARTY CLAIMS RESULTING FROM THE
+C     ACTIONS OF RECIPIENT IN THE USE OF THE SOFTWARE.
+C
+       implicit none
+
+       integer NMAX                    ! Maximum number of ephemeris constants 
+       parameter (NMAX = 1000)
+
+       character*6       NAMS(NMAX)    ! Names of ephemeris constants
+       double precision  VALS(NMAX)    ! Values of ephemeris constants
+
+       character*3  ALF3
+
+       double precision  TDB            ! Ephemeris time, in Julian days
+       double precision  PV(6)          ! Quantity requested 
+       double precision  SS(3)          ! Start JD, end JD of ephemeris file
+C                                       ! and span (days) of basic data block
+       double precision  JDEPOC         ! Initial JD for integration
+       double precision  XI
+       double precision  DEL
+       double precision TDBMIN, TDBMAX
+       data TDBMIN / 99.D99/
+       data TDBMAX /-99.d99/
+  
+       integer  I
+       integer  LINE
+       data LINE/0/
+       integer  NCON,NTARG,NCTR,NCOORD
+       integer  NPT
+       data NPT/100/
+
+       logical OKAY
+       data OKAY/.true./
+
+       logical AU_KM, DAY_SEC, IAU_AU
+       data AU_KM /.true./
+       data DAY_SEC/.true./
+       data IAU_AU/.false./
+
+C      Write a fingerprint to the screen.
+
+       write(*,*) ' JPL TEST-EPHEMERIS program. ' //
+     .            ' Last modified 15 March 2014.'
+
+       call PL_UNITS(AU_KM , DAY_SEC , IAU_AU)
+
+C     When called before first call to PLEPH or DPLEPH, PL_UNITS
+C     allows overriding the default units returned for positions and velocities.
+C
+C     AU_KM        True  means output length unit is astronomical units
+C                  False means output length unit is km
+C
+C     DAY_SEC      True means velocities are returned in length/day
+C                  False means velocities are returned in length/second
+C
+C     IAU_AU       True means use value of astronomical unit adopted in 2012
+C                       (149597870.700 km) if AU_KM is True
+C                  False means use value of astronomical units used at time
+C                        of ephemeris integration.
+C                  (Note that the value of AU returned in the ephemeris
+C                   constants will not be changed by this option).
+
+C      Print the ephemeris constants.
+
+       call  CONST (NAMS, VALS, SS, NCON)
+
+       write (*,'(/3F14.2)') SS
+       
+       JDEPOC = 2440400.5d0
+
+       do I = 1,NCON
+         if (NAMS(I) .EQ. 'JDEPOC') JDEPOC = VALS(I)
+         write(6,'(A8,D24.16)')NAMS(I),VALS(I)
+       enddo
+
+C     Skip the testpo.xxx comments at top of file
+
+   1  continue
+
+      read(*,'(a3)') ALF3
+      if (ALF3 .ne. 'EOT') go to 1
+
+      write(*,*) 
+     & '  line -- jed --   t#   c#   x#   --- jpl value ---'//
+     & '   --- user value --    -- difference --'
+      write(*,*) 
+
+C     Read a value from the test case; skip if not within the time-range
+C     of the present version of the ephemeris
+
+   2  continue
+
+      read(*,'(15X,D10.1,3I3,F30.20)',END=9)  
+     & TDB,NTARG,NCTR,NCOORD,XI
+
+CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+      if (TDB .lt. SS(1)) go to 2
+      if (TDB .gt. SS(2)) go to 2
+
+      call  PLEPH ( TDB, NTARG, NCTR, PV )
+
+CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+
+C     For testing purposes DEL is the computation of the difference in
+C       read values of the ephemeris converted from the export ascii files
+C       versus those printed form the original integration.
+C     The difference is checked for random parameters, 
+C     one every 32 day interval.
+C     The agreement is considered okay if DEL is less that 1e-13.
+C     This corresponds to a few cm for body positions, and very small
+C     values for velocities, and angles and their rates.
+C       (A fractional test isn't suitable since sometimes the values will
+C        be near zero for particular components.)
+C     For lunar libration psi, NCOORD=15, the angle accumulates in time
+C     so precision is lost after several centuries. 
+C     This is handled below by scaling DEL down for psi, 
+C     by 100 radians per year from the reference epoch,
+c     as opposed to having different tolerances for different quantities.
+
+      DEL = abs(PV(NCOORD)-XI)
+
+      if(NTARG .eq. 15 .and. NCOORD .eq. 3)then
+        DEL = DEL/(1.D0+100.D0*abs(TDB-JDEPOC)/365.25d0)
+      endif
+
+      LINE = LINE+1
+
+      if ( mod(LINE,NPT) .eq. 0 )then
+        write(*,200) LINE,TDB,NTARG,NCTR,NCOORD,XI,PV(NCOORD),DEL
+      endif
+
+      if(TDB .lt. TDBMIN) TDBMIN = TDB 
+      if(TDB .gt. TDBMAX) TDBMAX = TDB 
+
+ 200  format(i6,f10.1,3i5,2f25.13,1e13.5)
+
+C     Print out WARNING if difference greater than tolerance.
+
+      if (DEL .ge. 1.d-13) then
+        write(*,201)LINE,TDB,NTARG,NCTR,NCOORD,XI,PV(NCOORD),DEL
+        OKAY = .false.
+      endif
+
+ 201  format(/ '*****  WARNING : next difference >= 1.D-13  *****'//
+     & I6,F10.1,3I3,2F25.13,1E13.5/' ')
+
+      go to 2
+
+   9  continue
+
+      if(OKAY)then
+        write(*,*)'TESTEPH checked successfully against ephemeris file'
+        write(*,*)'over Julian day range ',TDBMIN,' to ',TDBMAX
+      else
+        write(*,*)'TESTEPH found problems with ephemeris file'
+      endif
+
+      stop
+      end
+C
+CCC
+C
+      subroutine PLEPH( TDB, NTARG, NCENT, PV)
+C
+C++++++++++++++++++++++++++
+C
+C     PLEPH reads the JPL planetary ephemeris file.
+C     For 'bodies' (Sun, Moon, planets, Earth-Moon barycenter, 
+C     solar-system-barycenter) the position and velocity of the 'body' NTARG 
+C     are given with respect to the 'body' NCENT. 
+C     
+C     Auxiliary values are 1980 IAU nutation angles, lunar libration angles,
+C     lunar Euler angle rates, and TT-TDB may also be available.
+C
+C     TDB is Ephemeris coordinate time, expressed in Julian days
+C
+C     The numbering for NTARG and NCENT is:
+C
+C                 1 = Mercury
+C                 2 = Venus
+C                 3 = Earth
+C                 4 = Mars system barycenter
+C                 5 = Jupiter system barycenter
+C                 6 = Saturn system barycenter
+C                 7 = Uranus system barycenter
+C                 8 = Neptune system barycenter
+C                 9 = Pluto system barycenter
+C                10 = Moon (of Earth)
+C                11 = Sun
+C                12 = Solar-System Barycenter
+C                13 = Earth-Moon barycenter
+C                14 = Nutations (Longitude and Obliquity)
+C                15 = Lunar Euler angles: phi, theta, psi
+C                16 = Lunar angular velocity: omegax, omegay, omegaz
+C                17 = TT - TDB
+C
+C     Note that not all ephemerides include all of the above quantities.
+C     When a quantity is requested that is not on the file,
+C     a warning is printed and the components of PV are set to -99.d99,
+C     which is not a valid value for any quantity.
+C
+C      For nutations, librations, and TT-TDB,  NCENT is ignored     
+C
+C      PV(6)    Returned values; 
+C 
+C            For 'bodies', x,y,z, and vx,vy,vz are returned.
+C            The values stored on the files are in units of km and km/s.
+C            By default, the positions are scaled the value of the astronomical
+C            unit used in the ephemeris integration to return units of 
+C            au and au/day.
+C            The user can override the default units by calling PLUNITS 
+C            as described below.
+C
+C            For nutation angles, the returned values in PV are 
+C                 [1-longitude, 2-obliquity, 3-long. rate, 4-oblq. rate]
+C                 in units of radians and radians/day.
+C            
+C            For libration angles, the returned values in PV are 
+C                 [1-omegax, 2-omega-y, 3=omega-z, 4-6 rates]
+C                 in units of radians/day and radians/day**2.
+C            
+C            For TDB-TT, PV(1) is TT-TDB in seconds, 
+C                        PV(2) rate of change of TT-TDB in sec/day
+C
+C     In addition to the main entry PLEPH, there are optional entry points.
+C
+C
+C     entry DPLEPH( TDB2, NTARG, NCENT, PV)
+C
+C     Inputs TDB2, NTARG, NCENT and output PV are as described above for PLEPH,
+C     except that TDB2 is a two-element array allowing the possibility
+C     of specifying the TDB coordinate time with greater numerical precision.
+C     Typically TDB2(1) is set to the integer number of the Julian day,
+C     and TDB(2) is set to the fraction of the Julian day.
+C
+C     Note that with ephemeris data in 32-day long blocks, the 
+C     precision of the ephemeris lookup time is limited to approximately
+C     ~1.e-15*(32 days) = ~3 nanoseconds
+C     since the Chebyshev coefficients are interpolated using a
+C     double precision representation of a fraction of the block time span.
+C
+C
+C     entry CONST(NAMS,VALS,SS,NCON)
+C
+C     No input arguments, output quantities are:
+C
+C        NAMS       6-character names of ephemeris constants
+C        VALS       double precision values of ephemeris constants
+C        SS         earliest TDB time on ephemeris (Julian days),
+C                   latest TDB time on ephemeris   (Julian days), and
+C                   number of days covered by each ephemeris record
+C        NCON       number of ephemeris constants
+C
+C
+C     entry PL_UNITS(AU_KM,DAY_SEC,IAU_AU)
+C
+C     When called before first call to PLEPH or DPLEPH or CONST, this entry
+C     allows overriding the default units returned for positions and velocities.
+C
+C     AU_KM        True  means output length unit is astronomical units
+C                  False means output length unit is km
+C
+C     DAY_SEC      True means velocities are returned in length/day
+C                  False means velocities are returned in length/second
+C
+C     IAU_AU       True means use value of astronomical unit adopted in 2012
+C                       (149597870.700 km) if AU_KM is True
+C                  False means use value of astronomical units used at time
+C                        of ephemeris integration.
+C                  (Note that the value of AU returned in the ephemeris
+C                   constants will not be changed by this option).
+C
+C     Defaults correspond to PL_UNITS(.TRUE. , .TRUE. , .FALSE.)
+C
+C     Last updated 14 March 2015
+C
+C$ Disclaimer
+C
+C     THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE
+C     CALIFORNIA INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S.
+C     GOVERNMENT CONTRACT WITH THE NATIONAL AERONAUTICS AND SPACE
+C     ADMINISTRATION (NASA). THE SOFTWARE IS TECHNOLOGY AND SOFTWARE
+C     PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS AND IS PROVIDED "AS-IS"
+C     TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND, INCLUDING ANY
+C     WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR A
+C     PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC
+C     SECTIONS 2312-2313) OR FOR ANY PURPOSE WHATSOEVER, FOR THE
+C     SOFTWARE AND RELATED MATERIALS, HOWEVER USED.
+C
+C     IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA
+C     BE LIABLE FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT
+C     LIMITED TO, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+C     INCLUDING ECONOMIC DAMAGE OR INJURY TO PROPERTY AND LOST PROFITS,
+C     REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE ADVISED, HAVE
+C     REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
+C
+C     RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF
+C     THE SOFTWARE AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY
+C     CALTECH AND NASA FOR ALL THIRD-PARTY CLAIMS RESULTING FROM THE
+C     ACTIONS OF RECIPIENT IN THE USE OF THE SOFTWARE.
+C     
+C++++++++++++++++++++++++++
+
+      implicit none
+
+      integer NMAX
+      parameter (NMAX=3000)
+
+C++++++++++++++++++++++++++
+
+C     arguments for main call PLEPH
+
+C++++++++++++++++++++++++++
+
+      double precision TDB
+      integer          NTARG,NCENT
+
+      double precision PV(6)
+
+C     argument for DPLEPH
+
+      real*8         TDB2(2)
+
+C++++++++++++++++++++++++++
+
+C     arguments for return CONST
+
+C++++++++++++++++++++++++++
+
+      character*6      NAMS1(*)
+      double precision VALS1(*)
+      double precision SS1(*)
+      integer NCON1
+
+C++++++++++++++++++++++++++
+
+C     arguments for PL_UNITS (overwrite default values in PLEPH)
+      
+C++++++++++++++++++++++++++
+
+      logical AU_KM1
+      logical DAY_SEC1
+      logical IAU_AU1
+
+C++++++++++++++++++++++++++
+
+C     internal variables
+
+C++++++++++++++++++++++++++
+
+      character*6      NAMS(NMAX)
+      double precision VALS(NMAX)
+      double precision SS(3)
+      double precision data(NMAX)
+      double precision PV1(6),PV2(6),PVM(6),PVB(6)
+
+      integer NCON
+
+      double precision T1,T2,TF,TF1,TF2
+      double precision FACTE,FACTM,XSCALE,VSCALE,SUMT
+      integer          NRFILE,NCOEFF
+      integer          IPT(3,15)
+
+      double precision SECSPAN
+      double precision SECDAY/86400.D0/
+
+      integer IPVA     /2/
+
+      integer          KODE(15)
+      data KODE        /1,2,13,4,5,6,7,8,9,13,11,0,3,3,15/
+
+      logical          AU_KM    /.true./
+      logical          DAY_SEC  /.true./
+      logical          IAU_AU   /.false./
+
+      logical          FIRST    /.true./
+      logical          RDCONST  /.false./
+
+      integer          I
+      integer          NRREC / 0/
+
+      save
+
+C++++++++++++++++++++++++++
+
+C     Main entry point PLEPH
+
+      T1 = TDB
+      T2 = 0.D0
+
+      go to 1
+
+C++++++++++++++++++++++++++
+
+      entry DPLEPH( TDB2, NTARG, NCENT, PV)
+
+C     Typically TDB2(1) is set to the integer number of the Julian day,
+C     and TDB(2) is set to the fraction of the Julian day.
+
+      T1 = TDB2(1)
+      T2 = TDB2(2)
+
+      go to 1
+
+C++++++++++++++++++++++++++
+
+      entry CONST(NAMS1,VALS1,SS1,NCON1)
+C
+C     This entry allows one to retrieve all of the constants associated with
+C     the ephemeris file. The values returned are copies of the values
+C     read off the ephemeris file and saved within PLEPH.
+C
+C     There is no INPUT
+C
+C     OUTPUT:
+C
+C     NCON           [integ.] : number of ephemeris constants
+C     NAMS           [char*6] : names of NCON ephemeris constants
+C     VALS           [d.p.]   : values of NCON ephemeris constants
+C     SS(3)          [d.p.]   : SS(1) is starting JED of the ephemeris file
+C                               SS(2) is  ending JED of the ephemeris file
+C                               SS(3) is the length(in days) of a file record
+C
+      RDCONST = .true.
+
+C++++++++++++++++++++++++++
+
+ 1    continue
+
+      if (FIRST) then 
+        call READHD( 
+     &       AU_KM,DAY_SEC,IAU_AU,
+     &       NMAX,NCON,NAMS,VALS,SS,IPT,
+     &       FACTE,FACTM,XSCALE,VSCALE,
+     &       NRFILE,NCOEFF)
+         if(NCOEFF .gt. NMAX)stop 'Coefficient array too small in PLEPH' 
+         FIRST = .false.
+         SECSPAN = SECDAY * SS(3)
+         do I = 1,NMAX
+           DATA(I) = -999999999999999.d0
+         enddo
+       endif
+
+      if(RDCONST) then
+
+        NCON1 = NCON
+        do I = 1,NCON
+          NAMS1(I) = NAMS(I)
+          VALS1(I) = VALS(I)
+        enddo
+
+        do I = 1,3
+          SS1(I) = SS(I)
+        enddo
+        RDCONST = .false.
+        return
+      endif
+
+C-----------------------------------------------------------------------
+C     start main ephemeris lookup operation
+C-----------------------------------------------------------------------
+
+C-----------------------------------------------------------------------
+C     first check to see if NTARG and NCENT in allowed ranges
+C-----------------------------------------------------------------------
+
+      if (NTARG .le. 0)  stop 'invalid NTARG < 0 in PLEPH'
+      if (NTARG .gt. 17) stop 'invalid NTARG >17 in PLEPH'
+      if (NCENT .le. 0)then
+        if(NTARG .lt. 14) stop 'invalid NCENT < 0 in PLEPH'
+      endif
+      if (NCENT .gt. 13)then
+        if(NTARG .lt. 14) stop 'invalid NCENT > 13 in PLEPH'
+      endif
+
+      if(NTARG .le. 13 .and. NCENT .ge. 14)then
+        stop 'invalid NCENT >13 in for body PLEPH'
+      endif
+
+      if(NTARG .le. 13 .and. NTARG .eq. NCENT)then
+        do i=1,6
+          PV(I) = 0.d0
+        enddo
+        return
+      endif
+
+C-----------------------------------------------------------------------
+C     determine which data record needed; read in if not already in DATA array
+C-----------------------------------------------------------------------
+
+      SUMT = T1+T2
+
+      if (SUMT .lt. SS(1)) stop 'input time before file start in PLEPH'
+      if (SUMT .gt. SS(2)) stop 'input time after  file start in PLEPH'
+
+      I = INT( (SUMT-SS(1))/SS(3) ) + 3
+      if(SUMT .eq. SS(2)) I = I - 1
+
+      if (I .ne. NRREC)then
+        NRREC = I
+        read (NRFILE, rec = NRREC, ERR = 99)(DATA(I),I=1,NCOEFF)
+      endif
+
+      TF1 = dble(int(T1))
+      TF2 = T1-TF1
+      TF  = (TF1-DATA(1))/SS(3)
+      TF  = TF + ((TF2+T2)/SS(3))
+
+C-----------------------------------------------------------------------
+C     do lookups for nutations, Euler angles, omega, or TT-TDB
+C     which do not require a center, and might not be on file
+C-----------------------------------------------------------------------
+
+C     nutation
+
+      if(NTARG .eq. 14) then
+        if(IPT(1,12) .gt. 0  .and. IPT(2,12)*IPT(3,12) .ne. 0)then
+          call INTCHB( DATA(IPT(1,12)), TF, SECSPAN,
+     *                 IPT(2,12), 2, IPT(3,12), IPVA, PV)
+          PV(3) = SECDAY*PV(3)   ! always convert radian/second to radian/day
+          PV(4) = SECDAY*PV(4)
+          PV(5) = -99.D99
+          PV(6) = -99.D99
+          return
+        else
+          write(6,*)'Nutations requested but not found on file'
+          do I = 1,6
+            PV(I) = -99.d99
+          enddo
+        endif
+        return
+      endif
+
+C     Lunar mantle Euler angles
+
+      if(NTARG .eq. 15) then
+        if(IPT(1,13) .gt. 0  .and. IPT(2,13)*IPT(3,13) .ne. 0)then
+          call INTCHB( DATA(IPT(1,13)), TF, SECSPAN,
+     *                 IPT(2,13), 3, IPT(3,13), IPVA, PV)
+          PV(4) = SECDAY*PV(4)   ! always convert radian/second to radian/day
+          PV(5) = SECDAY*PV(5)
+          PV(6) = SECDAY*PV(6)
+          return
+        else
+          write(6,*)'Mantle Euler angles requested but not on file'
+          do I = 1,6
+            PV(I) = -99.d99
+          enddo
+        endif
+        return
+      endif
+
+C     Lunar mantle angular velocity
+
+      if(NTARG .eq. 16) then
+        if(IPT(1,14) .gt. 0  .and. IPT(2,14)*IPT(3,14) .ne. 0)then
+          call INTCHB( DATA(IPT(1,14)), TF, SECSPAN,
+     *                 IPT(2,14), 3, IPT(3,14), IPVA, PV)
+          PV(4) = SECDAY*PV(4)   ! always convert to radian/day**2
+          PV(5) = SECDAY*PV(5)
+          PV(6) = SECDAY*PV(6)
+          return
+        else
+          write(6,*)'Mantle angular velocity requested but not on file'
+          do I = 1,6
+            PV(I) = -99.d99
+          enddo
+        endif
+        return
+      endif
+
+C     TT-TDB
+
+      if(NTARG .eq. 17) then
+        if(IPT(1,15) .gt. 0  .and. IPT(2,15)*IPT(3,15) .ne. 0)then
+          call INTCHB( DATA(IPT(1,15)), TF, SECSPAN,
+     *                 IPT(2,15), 1, IPT(3,15), IPVA, PV)
+          PV(2) = SECDAY*PV(2)   ! always convert second/second to second/day
+          do I = 3,6
+            PV(I) = -99.d99
+          enddo
+          return
+        else
+          write(6,*)'TT-TDB requested but not found on file'
+          do I = 1,6
+            PV(I) = -99.d99
+          enddo
+        endif
+        return
+      endif
+
+C-----------------------------------------------------------------------
+C     do lookups for bodies
+C-----------------------------------------------------------------------
+
+      if(NTARG .eq. 10 .and. NCENT .eq. 3)then
+        call INTCHB( DATA(IPT(1,10)), TF, SECSPAN,
+     *               IPT(2,10), 3, IPT(3,10), IPVA, PVM)
+        do I = 1,3
+          PV(i)   = PVM(i)*XSCALE
+          PV(i+3) = PVM(i+3)*VSCALE
+        enddo
+        return
+      endif
+
+      if(NTARG .eq. 3 .and. NCENT .eq. 10)then
+        call INTCHB( DATA(IPT(1,10)), TF, SECSPAN,
+     *               IPT(2,10), 3, IPT(3,10), IPVA, PVM)
+        do I = 1,3
+          PV(i)   = -PVM(i)*XSCALE
+          PV(i+3) = -PVM(i+3)*VSCALE
+        enddo
+        return
+      endif
+
+      do I = 1,6
+        PV1(I) = 0.d0
+        PV2(I) = 0.d0
+      enddo
+
+      if(NTARG .eq. 3 .or. NTARG .eq. 10 .or.
+     &   NCENT .eq. 3 .or. NCENT .eq. 10)then
+
+         call INTCHB( DATA(IPT(1,10)),
+     *               TF, SECSPAN, IPT(2,10), 3, IPT(3,10), IPVA, PVM)
+         call INTCHB( DATA(IPT(1,3)),
+     *               TF, SECSPAN, IPT(2,3),  3, IPT(3,3),  IPVA, PVB)
+
+        if(NTARG .eq. 3 .or. NTARG .eq. 10)then
+
+          if(NCENT .lt. 12)then
+            call INTCHB( DATA(IPT(1,NCENT)),TF, SECSPAN,
+     *                 IPT(2,NCENT), 3, IPT(3,NCENT), IPVA, PV2)
+          else if(NCENT .eq. 13)then
+            call INTCHB( DATA(IPT(1,3)),TF, SECSPAN,
+     *                 IPT(2,3), 3, IPT(3,3), IPVA, PV2)
+          endif
+
+          if(NTARG .eq. 3)then
+            do I = 1,6
+              PV(I) = PVB(I) - FACTE*PVM(I) - PV2(I)
+            enddo
+          else
+            do I=1,6
+              PV(I) = PVB(I) - FACTM*PVM(I) - PV2(I)
+            enddo
+          endif
+
+        else 
+
+          if(NTARG .lt. 12) then
+            call INTCHB( DATA(IPT(1,NTARG)),TF, SECSPAN,
+     *                 IPT(2,NTARG), 3, IPT(3,NTARG), IPVA, PV1)
+          else if (NTARG .eq. 13)then
+            call INTCHB( DATA(IPT(1,3)),TF, SECSPAN,
+     *                 IPT(2,3), 3, IPT(3,3), IPVA, PV1)
+          endif
+
+          if(NCENT .eq. 3)then
+            do I = 1,6
+              PV(I) = PV1(I) - (PVB(I) - FACTE*PVM(I))
+            enddo
+          else
+            do I=1,6
+              PV(I) = PV1(I) - (PVB(I) - FACTM*PVM(I))
+            enddo
+          endif
+        endif
+
+        do I = 1,3
+          PV(i)   = PV(i)*XSCALE
+          PV(i+3) = PV(i+3)*VSCALE
+        enddo
+        return
+      endif
+
+C -- Only cases left involve neither Earth nor Moon
+
+      if(NTARG .lt. 12) then
+        call INTCHB( DATA(IPT(1,NTARG)),TF, SECSPAN,
+     *                 IPT(2,NTARG), 3, IPT(3,NTARG), IPVA, PV1)
+      else if (NTARG .eq.13)then
+        call INTCHB( DATA(IPT(1,3)),TF, SECSPAN,
+     *                 IPT(2,3), 3, IPT(3,3), IPVA, PV1)
+        endif
+        
+      if(NCENT .lt. 12)then
+        call INTCHB( DATA(IPT(1,NCENT)),TF, SECSPAN,
+     *                 IPT(2,NCENT), 3, IPT(3,NCENT), IPVA, PV2)
+      else if (NCENT .eq. 13)then
+        call INTCHB( DATA(IPT(1,3)),TF, SECSPAN,
+     *                 IPT(2,3), 3, IPT(3,3), IPVA, PV2)
+      endif
+
+      do I = 1,3
+        PV(i)   = (PV1(I) - PV2(I) )     * XSCALE
+        PV(i+3) = (PV1(I+3) - PV2(I+3) ) * VSCALE
+      enddo
+      return
+
+C-----------------------------------------------------------------------
+
+      entry PL_UNITS(AU_KM1, DAY_SEC1, IAU_AU1)
+
+      AU_KM   = AU_KM1
+      DAY_SEC = DAY_SEC1
+      IAU_AU  = IAU_AU1
+
+      return
+
+C-----------------------------------------------------------------------
+
+ 99   continue
+
+      write(6,*)'Error reading ephemeris data record in PLEPH'
+      write(6,*)'T1,T2 = ',T1,T2
+      write(6,*)'Record not found = ',NRREC
+      stop
+
+      end
+C
+CCC
+C
+      subroutine READHD(
+     &           AU_KM,DAY_SEC,IAU_AU,
+     &           NMAX,NCON,NAMS,VALS,SS,IPT,
+     &           FACTE,FACTM,XSCALE,VSCALE,
+     &           NRFILE,NCOEFF)
+C
+C     Read the first record of a JPL binary planetary ephemeris file
+C     to determine the record length, return the ephemeris constants,
+C     and calculate scale factors to be used in PLEPH.
+C
+C$ Disclaimer
+C
+C     THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE
+C     CALIFORNIA INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S.
+C     GOVERNMENT CONTRACT WITH THE NATIONAL AERONAUTICS AND SPACE
+C     ADMINISTRATION (NASA). THE SOFTWARE IS TECHNOLOGY AND SOFTWARE
+C     PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS AND IS PROVIDED "AS-IS"
+C     TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND, INCLUDING ANY
+C     WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR A
+C     PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC
+C     SECTIONS 2312-2313) OR FOR ANY PURPOSE WHATSOEVER, FOR THE
+C     SOFTWARE AND RELATED MATERIALS, HOWEVER USED.
+C
+C     IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA
+C     BE LIABLE FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT
+C     LIMITED TO, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+C     INCLUDING ECONOMIC DAMAGE OR INJURY TO PROPERTY AND LOST PROFITS,
+C     REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE ADVISED, HAVE
+C     REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
+C
+C     RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF
+C     THE SOFTWARE AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY
+C     CALTECH AND NASA FOR ALL THIRD-PARTY CLAIMS RESULTING FROM THE
+C     ACTIONS OF RECIPIENT IN THE USE OF THE SOFTWARE.
+C
+      implicit none
+
+C     Input parameters:
+
+      logical AU_KM
+      logical DAY_SEC
+      logical IAU_AU
+      integer NMAX
+
+C     Output parameters: 
+
+      integer          NCON
+      integer          NCOEFF
+      integer          NRFILE
+      integer          IPT(3,15)
+      double precision VALS(*),SS(3)
+      double precision FACTE,FACTM
+      double precision XSCALE,VSCALE
+      character*6      NAMS(*)
+
+C     Local variables
+
+      integer   OLDMAX
+      parameter ( OLDMAX = 400)
+
+      integer NRECL/0/
+      integer KSIZE
+      integer NUMDE
+      data NUMDE /0/
+      character*6 TTL (14,3)
+      character*80 NAMFIL
+
+      double precision AU,EMRAT
+      double precision iau/149597870.700d0/
+
+      integer I,J,K,IRECSZ
+
+C ************************************************************************
+C ************************************************************************
+
+C     The user must select one of the following by deleting the 'C' in column 1
+
+C ************************************************************************
+
+C        call FSIZER1(NRECL,KSIZE,NRFILE,NAMFIL)
+        call FSIZER2(NRECL,KSIZE,NRFILE,NAMFIL)
+C        call FSIZER3(NRECL,KSIZE,NRFILE,NAMFIL)
+
+C ************************************************************************
+C ************************************************************************
+
+      if(NRECL .EQ. 0) WRITE(*,*)'  ***** FSIZER IS NOT WORKING *****'
+
+      IRECSZ = NRECL*KSIZE
+      NCOEFF = KSIZE/2
+
+      open(NRFILE,
+     *       FILE   = NAMFIL,
+     *       ACCESS ='DIRECT',
+     *       FORM   ='UNFORMATTED',
+     *       RECL   = IRECSZ,
+     *       STATUS ='OLD')
+
+      read(NRFILE,REC=1)TTL,(NAMS(K),K=1,OLDMAX),SS,NCON,AU,EMRAT
+
+      if (NCON .le. OLDMAX) then
+
+        read(NRFILE,REC=1)TTL,(NAMS(K),K=1,OLDMAX),SS,NCON,AU,EMRAT,
+     &       ((IPT(I,J),I=1,3),J=1,12),NUMDE,(IPT(I,13),I=1,3),
+     &                                       (IPT(I,14),I=1,3),
+     &                                       (IPT(I,15),I=1,3)
+
+        read(NRFILE,REC=2)(VALS(I),I=1,OLDMAX)
+
+      else
+
+        if(NCON .gt. NMAX) then
+          write(*,*)'Number of ephemeris constants too big in READHD'
+          stop
+        endif
+
+        read(NRFILE,REC=1)TTL,(NAMS(K),K=1,OLDMAX),SS,NCON,AU,EMRAT,
+     &       ((IPT(I,J),I=1,3),J=1,12),NUMDE,(IPT(I,13),I=1,3),
+     &       (NAMS(J),J=K,NCON),
+     &                                       (IPT(I,14),I=1,3),
+     &                                       (IPT(I,15),I=1,3)
+
+        read(NRFILE,REC=2)(VALS(I),I=1,NCON)
+
+      endif
+
+      FACTE = 1.D0/(1.D0+EMRAT)
+      FACTM = FACTE - 1.D0
+
+      if(FACTE .eq. 0.D0) then
+        write(*,*)'Invalid value of EMRAT from file in READHD'
+        stop
+      endif
+
+      if(AU_KM)then
+        if(IAU_AU)then
+          XSCALE = 1.d0/IAU
+        else
+          XSCALE = 1.d0/AU
+        endif
+      else
+        XSCALE = 1.d0
+      endif
+
+      if(DAY_SEC) then
+        VSCALE = XSCALE*86400.d0
+      else
+        VSCALE = XSCALE
+      endif
+
+      if(NUMDE .eq. 0) stop 'DENUM not found by READHD in constants'
+      write(6,*)
+      write(6,'(a27,i3.3)')' JPL planetary ephemeris DE',NUMDE
+      write(6,*)'Requested output units are :'
+      if(AU_KM)then
+        if(IAU_AU)then
+          write(6,*)'IAU au for distance'
+          if(DAY_SEC)then
+            write(6,*)'IAU au/day for velocity'
+          else
+            write(6,*)'IAU au/sec for velocity'
+          endif
+        else
+          write(6,'(a2,i3.3,a16)')'DE',NUMDE,' au for distance'
+          if(DAY_SEC)then
+            write(6,'(a2,i3.3,a20)')'DE',NUMDE,' au/day for velocity'
+          else
+            write(6,'(a2,i3.3,a20)')'DE',NUMDE,' au/sec for velocity'
+          endif
+        endif
+      else
+        write(6,*)'km for distance'
+        if(DAY_SEC)then
+          write(6,*)'km/day for velocity'
+        else
+          write(6,*)'km/sec for velocity'
+        endif
+      endif
+
+      return
+      end
+C
+CCC
+C
+      subroutine FSIZER1(NRECL,KSIZE,NRFILE,NAMFIL)
+C
+C     FSIZER1 uses the INQUIRE statement to find out the record length 
+C     of the direct access file before opening it.  
+
+C     This procedure is non-standard, but seems to work for VAX machines. 
+
+C$ Disclaimer
+C
+C     THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE
+C     CALIFORNIA INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S.
+C     GOVERNMENT CONTRACT WITH THE NATIONAL AERONAUTICS AND SPACE
+C     ADMINISTRATION (NASA). THE SOFTWARE IS TECHNOLOGY AND SOFTWARE
+C     PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS AND IS PROVIDED "AS-IS"
+C     TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND, INCLUDING ANY
+C     WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR A
+C     PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC
+C     SECTIONS 2312-2313) OR FOR ANY PURPOSE WHATSOEVER, FOR THE
+C     SOFTWARE AND RELATED MATERIALS, HOWEVER USED.
+C
+C     IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA
+C     BE LIABLE FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT
+C     LIMITED TO, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+C     INCLUDING ECONOMIC DAMAGE OR INJURY TO PROPERTY AND LOST PROFITS,
+C     REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE ADVISED, HAVE
+C     REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
+C
+C     RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF
+C     THE SOFTWARE AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY
+C     CALTECH AND NASA FOR ALL THIRD-PARTY CLAIMS RESULTING FROM THE
+C     ACTIONS OF RECIPIENT IN THE USE OF THE SOFTWARE.
+C
+      implicit none
+
+      integer NRECL,KSIZE,NRFILE
+      integer IRECSZ
+
+C  *****************************************************************
+C  *****************************************************************
+
+C     The parameters NAMFIL, NRECL, and NRFILE are to be set by the user
+
+C  *****************************************************************
+
+C     NRECL=1 if "RECL" in the OPEN statement is the record length in 
+C             single-precisions words
+C     (for VAX/VMS, NRECL is probably 1)
+
+C     NRECL=4 if "RECL" in the OPEN statement is the record length in bytes
+C     (for Unix/Linux, NRECL is probably 4)
+
+C      NRECL = 
+
+C  *****************************************************************
+
+C     NRFILE is the internal unit number used for the ephemeris file
+
+C      NRFILE = 12
+
+C  *****************************************************************
+
+C     NAMFIL is the external name of the binary ephemeris file
+
+      character*80  NAMFIL
+
+C      NAMFIL = 'JPLEPH'
+
+C  *****************************************************************
+C  *****************************************************************
+
+C     Find the record size using the INQUIRE function
+
+      IRECSZ = 0
+
+      inquire(FILE=NAMFIL,RECL=IRECSZ)
+
+C     If INQUIRE does not work, IRECSZ will usually be left at 0
+
+      if(IRECSZ .LE. 0) then
+        write(*,*)' INQUIRE STATEMENT PROBABLY DID NOT WORK'
+      endif
+
+      KSIZE = IRECSZ/NRECL
+
+      return
+
+      end
+C
+C++++++++++++++++++++++++
+
+      subroutine FSIZER2(NRECL,KSIZE,NRFILE,NAMFIL)
+
+C++++++++++++++++++++++++
+
+C     FSIZER2 opens the file, 'NAMFIL', with an arbitrarily large record length,
+C     reads the first record, and uses the information read to compute KSIZE,
+C     the number of single-precision words in a record.
+C
+      implicit none
+
+      double precision SS(3),AU,EMRAT
+
+      integer OLDMAX
+      parameter (OLDMAX = 400)
+      integer NMAX
+      parameter (NMAX = 1000)
+
+      integer IPT(3,15)
+      data IPT /45*0/
+
+      integer KSIZE,NRECL,NRFILE
+      integer I,J,K,ND,KHI,KMX,MRECL,NCON,NUMDE
+
+      character*6 TTL(14,3),CNAM(NMAX)
+      character*80 NAMFIL
+
+C  *****************************************************************
+C  *****************************************************************
+
+C     The parameters NRECL, NRFILE, and NAMFIL are to be set by the user
+
+C  *****************************************************************
+
+C     NRECL=1 if "RECL" in the OPEN statement is the record length in 
+C                       in single precision words
+C     (for VAX/VMS, NRECL is probably 1)
+
+C     NRECL=4 if "RECL" in the OPEN statement is the record length in bytes
+C     (for UNIX, NRECL is probably 4)
+
+      NRECL=4
+
+C  *****************************************************************
+
+C     NRFILE is the internal unit number used for the ephemeris file
+
+      NRFILE=12
+
+C  *****************************************************************
+
+C     NAMFIL is the external name of the binary ephemeris file
+
+      NAMFIL='JPLEPH' 
+
+C  *****************************************************************
+C  *****************************************************************
+
+C     Open the direct-access files and get the pointers in order to
+C     Determine the size of the ephemeris record.
+
+C     Starting with DE430, the number of ephemeris constants used
+C     in the integration exceeded the old maximum number of 400
+C     so the number of constants NCON is read first, to find
+C     the location of all the pointers.
+
+      MRECL = NRECL*10000
+
+        open(NRFILE,
+     *       FILE=NAMFIL,
+     *       ACCESS='DIRECT',
+     *       FORM='UNFORMATTED',
+     *       RECL=MRECL,
+     *       STATUS='OLD')
+
+      read(NRFILE,REC=1)TTL,(CNAM(K),K=1,OLDMAX),SS,NCON
+
+      if (NCON .le. OLDMAX) then
+
+        read(NRFILE,REC=1)TTL,(CNAM(K),K=1,OLDMAX),SS,NCON,AU,EMRAT,
+     &       ((IPT(I,J),I=1,3),J=1,12),NUMDE,(IPT(I,13),I=1,3),
+     &                                       (IPT(I,14),I=1,3),
+     &                                       (IPT(I,15),I=1,3)
+
+      else
+
+        if(NCON .gt. NMAX)then
+          write(*,*)'Number of ephemeris constants too big for FSIZER3'
+          stop
+        endif
+
+        read(NRFILE,REC=1)TTL,(CNAM(K),K=1,OLDMAX),SS,NCON,AU,EMRAT,
+     &       ((IPT(I,J),I=1,3),J=1,12),NUMDE,(IPT(I,13),I=1,3),
+     &       (CNAM(J),J=K,NCON),
+     &                                       (IPT(I,14),I=1,3),
+     &                                       (IPT(I,15),I=1,3)
+
+      endif
+
+      close(NRFILE)
+
+C     Find the number of data coefficients from the pointers
+
+      KMX = 0
+      KHI = 0
+
+      do I = 1,15
+         if (IPT(1,I) .ge. KMX) then
+            KMX = IPT(1,I)
+            KHI = I
+         endif
+      enddo
+
+      ND = 3
+      if (KHI .EQ. 12) ND=2
+      if (KHI .EQ. 15) ND=1
+
+      KSIZE = IPT(1,KHI) - 1 + ND*IPT(2,KHI)*IPT(3,KHI)
+      KSIZE = 2*KSIZE
+
+      return
+
+      end
+C++++++++++++++++++++++++
+
+      subroutine FSIZER3(NRECL,KSIZE,NRFILE,NAMFIL)
+
+C++++++++++++++++++++++++
+
+C     FSIZER3 requires the user to set the values of KSIZE
+C     as well as the values of NRECL, NRFILE, and NAMFIL.
+
+C     KSIZE is listed in the first line of the file header.xxx
+      
+      implicit none
+
+      integer KSIZE,NRECL,NRFILE
+      character*80 NAMFIL
+
+C  *****************************************************************
+C  *****************************************************************
+
+C     The parameters NRECL, NRFILE, NAMFIL and KSIZE are to be set by the user
+
+C  *****************************************************************
+
+C     NRECL=1 if "RECL" in the OPEN statement is the record length in 
+C             single-precisions words
+C     (for VAX/VMS, NRECL is probably 1)
+C
+C     NRECL=4 if "RECL" in the OPEN statement is the record length in bytes
+C     (for Unix/Linux, NRECL is probably 4)
+
+C       NRECL =
+
+C  *****************************************************************
+
+C     NRFILE is the internal unit number used for the ephemeris file
+
+      NRFILE = 12
+
+C  *****************************************************************
+
+C     NAMFIL is the external name of the binary ephemeris file
+
+      NAMFIL = 'JPLEPH'
+
+C  *****************************************************************
+
+C     KSIZE must be set by the user according to the ephemeris to be read
+
+C     For  de200, set KSIZE to 1652
+C     For  de405, set KSIZE to 2036
+C     For  de406, set KSIZE to 1456
+C     For  de414 through de429,  set KSIZE to 2036
+C     For  de430 & de431, versions without TT-TDB have KSIZE = 2036
+C                         versions with    TT-TDB have KSIZE = 1964
+
+C      KSIZE = 
+
+C  *****************************************************************
+C  *******************************************************************
+
+      RETURN
+
+      END
+C
+CCC
+C
+      subroutine INTCHB( BUF, T, LINT, NCF, NCM, NSC, REQ, PV)
+C
+C-----------------------------------------------------------------------
+C  INTCHB (INTerpolate CHeByshev polynomial) computes the components of
+C  position by interpolating Chebyshev polynomials, and if requested, it
+C  also computes the components of velocity by differentiating the
+C  Chebyshev polynomials and then interpolating.
+C
+C  Inputs:
+C
+C   BUF(1..NCF, 1..NCM, 1..NSC)  Chebyshev coefficients
+C   T     Fractional time within the interval covered by the
+C         coefficients at which the interpolation is required.
+C         T must satisfy 0 .LE. T .LE. 1
+C   LINT  Length of the interval in input time units
+C   NCF   Number of coefficients per component
+C   NCM   Number of components per set of coefficients
+C   NSC   Number of sets of coefficients within interval
+C   REQ   Request indicator:
+C           REQ= 1 for position components only,
+C           REQ= 2 for both position and velocity components.
+C
+C  Output:
+C
+C   PV(i)    Computed position and velocity components:
+C            1 to NCM are position components.
+C            NCM+1 to 2*NCM  are velocity components.
+C-----------------------------------------------------------------------
+C
+C$ Disclaimer
+C
+C     THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE
+C     CALIFORNIA INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S.
+C     GOVERNMENT CONTRACT WITH THE NATIONAL AERONAUTICS AND SPACE
+C     ADMINISTRATION (NASA). THE SOFTWARE IS TECHNOLOGY AND SOFTWARE
+C     PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS AND IS PROVIDED "AS-IS"
+C     TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND, INCLUDING ANY
+C     WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR A
+C     PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC
+C     SECTIONS 2312-2313) OR FOR ANY PURPOSE WHATSOEVER, FOR THE
+C     SOFTWARE AND RELATED MATERIALS, HOWEVER USED.
+C
+C     IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA
+C     BE LIABLE FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT
+C     LIMITED TO, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+C     INCLUDING ECONOMIC DAMAGE OR INJURY TO PROPERTY AND LOST PROFITS,
+C     REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE ADVISED, HAVE
+C     REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
+C
+C     RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF
+C     THE SOFTWARE AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY
+C     CALTECH AND NASA FOR ALL THIRD-PARTY CLAIMS RESULTING FROM THE
+C     ACTIONS OF RECIPIENT IN THE USE OF THE SOFTWARE.
+C
+      implicit none
+
+C     Input variables:
+
+      integer            NCF, NCM, NSC, REQ
+      double precision   BUF(NCF,NCM,NSC), T, LINT
+
+C     Output variables
+
+      double precision   PV(*)
+
+C     Local variable
+
+      double precision  PC(18), VC(2:18), TEMP, TC, TTC, BMA
+      integer    NS, L, NP, NV, NC, I, J
+
+      data       PC(1) /1.D0/, PC(2) /2.D0/, VC(2) /1.D0/
+
+      save
+
+C     Compute set number within interval (L), and scaled Chebyshev time
+C     within that set (TC).
+
+      NS   = NSC
+      TEMP = T * dble(NS)
+      TC   = 2.d0 * ( TEMP-DINT(TEMP) ) - 1.d0
+      L    = TEMP + 1
+      if (L .gt. NS) then
+        L  = L - 1
+        TC = TC + 2.d0
+      endif
+
+C-- If the Chebyshev time has changed, compute new polynomial values.
+
+      if (TC .ne. PC(2)) then
+        NP = 3
+        NV = 4
+        PC(2) = TC
+        TTC   = TC + TC
+        VC(3) = TTC + TTC
+       endif
+
+C-- Compute position polynomial values.
+
+      NC = NCF
+      do  NP = NP,NC
+        PC(NP) = TTC*PC(NP-1) - PC(NP-2)
+      enddo
+
+C-- Compute position components.
+
+      do I = 1,NCM
+        TEMP = 0.D0
+        do  J = NC,1,-1
+          TEMP= TEMP + PC(J)*BUF(J,I,L)
+        enddo
+        PV(I) = TEMP
+      enddo
+
+C-- If only positions are requested, exit
+
+      IF (REQ .LE. 1) RETURN
+
+C-- Compute velocity polynomial values.
+
+      do  NV = NV,NC
+        VC(NV)= TTC*VC(NV-1) + PC(NV-1) + PC(NV-1) - VC(NV-2)
+      enddo
+
+C-- Compute velocity components.
+
+      BMA = DBLE( 2*NS ) / LINT
+      do  I = 1,NCM
+        TEMP= 0.D0
+        do  J = NC,2,-1
+          TEMP= TEMP + VC(J)*BUF(J,I,L)
+        enddo
+        PV(I+NCM) = TEMP*BMA
+      enddo
+
+      return
+
+      end

--- a/fortran/userguide.txt
+++ b/fortran/userguide.txt
@@ -1,0 +1,301 @@
+INSTRUCTIONS FOR EPHEMERIS FILE ACCESS THROUGH FORTRAN PROGRAMS  - [24 March 2013]
+----------------------------------------------------------------------------------
+
+These instructions provide a guide to Fortran programs for converting, merging, 
+and reading JPL planetary ephemeris files.  The steps assume downloading of 
+ASCII ephemeris files, conversion of ASCII files to binary files, and reading the 
+binary files with a test program .
+
+Program "testeph" includes a simple calling program which reads and interpolates 
+planetary and lunar coordinates from a binary ephemeris file and compares 
+results at specific times against corresponding numbers produced at JPL and 
+stored in a file along with the ASCII ephemeris files. Most users will insert 
+the ephemeris reading subroutines from "testeph" into their own programs.
+
+The subroutines in "testeph" which read the ephemeris files interpolate the
+Chebyshev coefficients for the positions of the planets, Sun, and Moon, which 
+are stored in units of kilometers, and scales them by the value of the 
+astronomical unit (AU) stored on the ephemeris to return positions in units of AU. 
+Users who prefer to units of km will want to use the provided subroutine "CONST"
+ to read the value of the AU and scale the positions into kilometers.
+
+These instructions assume the user will start with the ASCII format files. Some
+users will be able to skip the step of converting ASCII files to binary files if 
+they can find binary files compatible with their system.
+
+
+FILES TO BE RETRIEVED BY THE USER
+------------------------------------
+
+(via anonymous ftp from ftp://ssd.jpl.nasa.gov)
+
+/pub/eph/planets/fortran/asc2eph.f
+/pub/eph/planets/fortran/testeph.f
+
+/pub/eph/planets/ascii/deXXX/ascSYYYY.XXX
+/pub/eph/planets/ascii/deXXX/testpo.XXX
+/pub/eph/planets/ascii/deXXX/header.XXX
+
+where "XXX" is a three-digit number of the desired planetary ephemeris 
+(e.g. 403), and "SYYYY" is the starting year of each particular ASCII file 
+("S" is the sign : "p" for + and "m" for -).
+
+The ASCII files come in blocks of 20 years or more. The ASCII files are 
+converted into binary files on the user's computer, using program "asc2eph".
+
+******************************************************************************
+
+BRIEF ITEM DESCRIPTION
+-----------------------
+
+asc2eph.f      : Program which converts the ASCII ephemeris file into binary
+                 format. 
+
+testeph.f      : Fortran program containing a main program which uses the 
+                 reading and interpolating subroutines.  This program 
+                 compares the results with similar runs made at JPL in order 
+                 to ensure that the ephemeris is installed and being read 
+                 correctly.
+
+ascSYYYY.XXX   : ASCII ephemeris files from JPL Ephemeris DEXXX,
+                 starting in the year SYYYY ("p/m" for  "+/-").  
+                 The ASCII ephemeris files may be converted separately 
+                 into binary ephemeris files using program "asc2eph" 
+                 or several ASCII ephemeris files can be input at one time 
+                 into "asc2eph" to make a longer binary file.
+
+header.XXX : Header information for ephemeris deXXX, needed by "asc2eph".
+
+testpo.XXX"    : Test results computed at JPL; these are input by the program
+                 testeph and are used for testing the ephemeris 
+                 installation.  There is a different test file for each 
+                 ephemeris; they must match or the test will not 
+                 work correctly.
+
+******************************************************************************
+
+ASCII to BINARY CONVERSION
+--------------------------
+
+To convert the ASCII blocks into a binary ephemeris, you must first 
+compile and run the program "asc2eph".  Before compiling "asc2eph.f" the user
+must edit the program to select length of a Fortran direct access record on the users
+platform by uncommentting one of the lines which specify the parameter 'NRECL'.
+The program "asc2eph" reads, via standard input, a header file followed by 
+one or more of the ASCII ephemeris blocks. 
+Thus, the input is "header.XXX" and (a series of) "ascSYYYY.XXX".  (The "S" 
+stands for the "sign": "p" for "+";"m" for "-".)  The blocks must be in order 
+with no gaps in the intervals of time-coverage.  The binary ephemeris is written
+onto a file called 'JPLEPH'.
+
+An example for running asc2eph on a PC is the following:
+
+    C:\> copy header.200+ascp1980.200+ascp2000.200+ascp2020.200  infile.200
+    C:\> asc2eph < infile.200
+
+In UNIX, one would use:
+
+    cat header.200 ascp1980.200 ascp2000.200 ascp2020.200 | asc2eph.e
+
+
+TESTING THE BINARY FILE
+-----------------------
+
+To check that the conversion from ASCII to binary ephemeris file has been done 
+successfully, the program, "testeph" is provided.  This program reads 
+ephemeris positions and compares the results with values computed at JPL, 
+contained in the file "testpo.XXX".
+
+Compilation of the program "testeph" requires tailoring of source code to work 
+on the users computer, since the program uses a native binary Fortran read 
+function that is implemented differently on different platforms. Instructions on 
+the required tailoring are given below.
+
+After compilation, running program "testeph" requires assigning the name 
+"JPLEPH" to the binary ephemeris file and sending "testpo.XXX" to 
+the executable via standard input. An example under the UNIX command line is after 
+creating the binary JPLEPH file from the DE200 ASCCI filers as described above is:
+
+    cat testpo.200 | testeph.e
+
+The program "testeph" will print out the list of ephemeris constants
+(retrieved by the subroutine "CONST") and will then use the subroutine
+"PLEPH" to read and interpolate the ephemeris for coordinates
+corresponding to the sample ones in "testpo.xxx".  If any comparison
+yields a difference larger than 10**(-13) [in units of au or au/day],
+an error message will be printed out.  Further, a line will be printed
+every 100 comparisons in any case, so that the progress can be monitored.
+
+
+TAILORING THE SOFTWARE
+----------------------
+
+The software was written in standard Fortran-77.  It should work on 
+any machine with a standard compiler.  
+
+HOWEVER, there are two parameters, NRECL, and KSIZE which must be defined
+by the user by editing the program before compilation.
+
+These parameters are set by the subroutine FSIZER1, FSIZER2, or FSIZER3.
+The user must determine which of these three subroutines is appropriate,
+select which is used by uncomenting the relevant line in the subroutine "STATE",
+comment lines needing values in the two non-used versions, and adding the correct
+values in the version selected.
+
+Records are stored on some platforms in single precison words (in which case NRECL = 1)
+or in bytes (in which case NRECL = 4). The user must select the correct value when
+editing the selected version of FSIZER.
+
+Each record of the binary ephemeris file has a length of KSIZE single precision words.
+KSIZE is not the same for each ephemeris. The three different versions of FSIZER
+determine KSIZE in different ways.
+
+FSIZER1     Uses the INQUIRE statement to find the length of the records
+            automatically before opening the file.  This works for VAX's;
+            not in UNIX.
+
+FSIZER2     Opens the file with a large arbitrary value of RECL, reads the first
+            record, and use the information on that record to determine the 
+            recordn length.  FSIZER2 then closes the file and passes the correct
+            value of KSIZE to the subroutinte STATE to re-open with the 
+            exact value. This seems to work for UNIX compilers as long as the 
+            initial value of RECL is less than the exact value but large enough 
+            to get the required information from the first file.
+            (For other compilers, this doesn't work since you can open a file 
+            only with the exact value of RECL.)
+
+FSIZER3     The user enters a fixed value for KSIZE based on the ephemeris file ins use.
+            KSIZE is 1652 for DE200, 2036 for DE4xx except DE406 for which KSIZE = 1456..
+
+The selected version of FSIZER also defines the file name Fortran unit number
+the binary ephemeris, which iare 12 and 'JPLEPH' respectively by default but can 
+be changed by the user if desired.
+
+MAIN READING SUBROUTINES
+------------------------
+
+Two of the subroutines called by "testeph.f" are of primary interest to the user:
+"PLEPH" and "CONST". Subroutines "DPLEPH", and "STATE" may also be useful.
+
+   PLEPH  :  Get the state vector (position and velocity) of one body with 
+              respect to another at any given time within the interval covered 
+              by the ephemeris.
+
+   CONST  :  Retrieve values of all of the constants on the ephemeris file.
+
+   DPLEPH :  Same as PLEPH, but with increased precision in the input time.
+
+   STATE  :  Read and interpolate the ephemeris file. (Called by PLEPH).
+
+
+C  NOTE : Over the years, different versions of PLEPH have had a 5th argument:
+C  sometimes, an error return statement number; sometimes, a logical denoting
+C  whether or not the requested date is covered by the ephemeris.  We apologize
+C  for this inconsistency; in this version, we use only the four necessary
+C  arguments and do the testing outside of the subroutine.
+
+
+**  PLEPH  ********  subroutine pleph( tdb, npl, nctr, pv)  **********
+
+    Input
+    -----
+          tdb [d.p.]  : julian ephemeris date
+          npl [int.]  : planet number
+          nctr [int.] : center number
+
+             identifications for "npl" and "nctr"
+             ------------------------------------
+              1 = mercury           8 = neptune
+              2 = venus             9 = pluto
+              3 = earth            10 = moon
+              4 = mars             11 = sun
+              5 = jupiter          12 = solar-system barycenter
+              6 = saturn           13 = earth-moon barycenter
+              7 = uranus           14 = nutations in longitude and obliquity
+                                   15 = librations (if they exist on the file)
+                 (for nutations and librations, nctr=0)
+    Output
+    ------
+          pv(6) [d.p.]  : x,y,z,x-dot,y-dot,z-dot [au, au/day]
+                  for nutations, d(psi), d(eps), d(psi)-dot, d(eps)-dot
+                                  [rads, rads/day]
+                  for librations, (Euler angles and rates, w.r.t. the ephemeris
+                                  reference frame)   [rads, rads/day]
+
+**  CONST  ********  subroutine const(nmv,vlv,sss,nrv)  **********
+
+    Input   (none)
+    -----
+
+    Output
+    ------
+     nmv(nrv) [char*6] : list of nrv names associated with the values in vlv
+     vlv(nrv) [d.p.]   : nrv values associated with the names in nmcc
+     sss(3) [d.p.]     :
+                            sss(1) : starting jed of the ephemeris file
+                            sss(2) : ending jed of the ephemeris file
+                            sss(3) : number of days covered by each block
+                                     of Chebychev coefficients
+     nrv [int.]        : number of values in nmv and vlv
+
+
+
+**  STATE  ********  subroutine state(jed,list,pv,nut,*)  **********
+           
+  [This subroutine is identical to that provided in the past; it is still 
+   provided to give previous users compatability; it is not recommended for 
+   use by first-time users.]
+                                                                     
+**  DPLEPH  ********  entry dpleph( tdb2, npl, nctr, pv)  **********
+
+  This entry is identical to "PLEPH", except that the input time, tdb2, is
+
+  doubly-dimensioned for increased precision  [ double precision tdb2(2) ].
+
+                          Any combination of tdb2(1)+tdb2(2) which falls within
+                          the time span on the file is a permissible epoch.    
+
+                                                                               
+                          For ease in programming, the user may put the entire 
+                          date into tdb2(1) and set tdb2(2)=0.        
+
+                          However, for maximum interpolation accuracy, set 
+                          tdb2(1) equal to the most recent midnight at or 
+                          before interpolation epoch (i.e., xxxxxxx.5d0) and 
+                          set tdb2(2) equal to the remaining fractional part 
+
+                          of the day.
+
+                          As an alternative, it may prove convenient to set 
+                          tdb2(1) equal to some fixed epoch, such as start of 
+                          integration, and set tdb2(2) equal to the remainder 
+                          of the desired epoch.
+
+******************************************************************************
+
+CONSTANTS ON THE EPHEMERIS FILE
+-------------------------------
+
+The following is a partial list of constants found on the ephemeris file:
+
+  DENUM           Planetary ephemeris number.
+  LENUM           Lunar ephemeris number.
+  TDATEF, TDATEB  Dates of the Forward and Backward Integrations
+  CLIGHT          Speed of light (km/s).
+  AU              Number of kilometers per astronomical unit.
+  EMRAT           Earth-Moon mass ratio.
+  GMi             GM for ith planet [au**3/day**2].
+  GMB             GM for the Earth-Moon Barycenter [au**3/day**2].
+  GMS             Sun (= k**2) [au**3/day**2].
+  X1, ..., ZD9    Initial conditions for the numerical integration,
+                  given at "JDEPOC", with respect to "CENTER".
+  JDEPOC          Epoch (JED) of initial conditions, normally JED 2440400.5.
+  CENTER          Reference center for the initial conditions.
+                  (Sun: 11,  Solar System Barycenter: 12)
+  MAiiii          GM's of asteroid number iiii [au**3/day**2].
+  PHI, THT, PSI   Euler angles of the orientation of the lunar mantle.
+  OMEGAX, ...     Rotational velocities of the lunar mantle.
+  PHIC,THTC,PSIC  Euler angles of the orientation of the lunar core.
+  OMGCX, ...      Rotational velocities of the lunar core.
+
+


### PR DESCRIPTION
Some Fortran tools are provided by JPL for use with NOVAS to merge and test ephemeris data, which were last updated in 2013.  These files are included for convenience from here:
    ftp://ssd.jpl.nasa.gov/pub/eph/planets/fortran/

From JPL's userguide.txt:

    asc2eph.f      : Program which converts the ASCII ephemeris file into binary
                     format.

    testeph.f      : Fortran program containing a main program which uses the
                     reading and interpolating subroutines.  This program
                     compares the results with similar runs made at JPL in order
                     to ensure that the ephemeris is installed and being read
                     correctly.

    [...]

    The software was written in standard Fortran-77.  It should work on
    any machine with a standard compiler.

    HOWEVER, there are two parameters, NRECL, and KSIZE which must be defined
    by the user by editing the program before compilation.

	[...]

	Records are stored on some platforms in single precison words (in which case NRECL = 1)
	or in bytes (in which case NRECL = 4). The user must select the correct value when
	editing the selected version of FSIZER.

	Each record of the binary ephemeris file has a length of KSIZE single precision words.
	KSIZE is not the same for each ephemeris. The three different versions of FSIZER
	determine KSIZE in different ways.  The three different versions of FSIZER
	determine KSIZE in different ways.

	FSIZER1     Uses the INQUIRE statement to find the length of the records
				automatically before opening the file.  This works for VAX's;
				not in UNIX.

	FSIZER2     Opens the file with a large arbitrary value of RECL, reads the first
				record, and use the information on that record to determine the
				recordn length.  FSIZER2 then closes the file and passes the correct
				value of KSIZE to the subroutinte STATE to re-open with the
				exact value. This seems to work for UNIX compilers as long as the
				initial value of RECL is less than the exact value but large enough
				to get the required information from the first file.
				(For other compilers, this doesn't work since you can open a file
				only with the exact value of RECL.)

	FSIZER3     The user enters a fixed value for KSIZE based on the ephemeris file ins use.
				KSIZE is 1652 for DE200, 2036 for DE4xx except DE406 for which KSIZE = 1456..

From fortran/testeph.f:

	C  KSIZE must be set by the user according to the ephemeris to be read

	C  For  de200, set KSIZE to 1652
	C  For  de405, set KSIZE to 2036
	C  For  de406, set KSIZE to 1456
	C  For  de414, set KSIZE to 2036
	C  For  de418, set KSIZE to 2036
	C  For  de421, set KSIZE to 2036
	C  For  de422, set KSIZE to 2036
	C  For  de423, set KSIZE to 2036
	C  For  de424, set KSIZE to 2036
	C  For  de430, set KSIZE to 2036

After setting NRECL and KSIZE, run `make fortran` to build them.

[ https://ssd.jpl.nasa.gov/ftp/eph/planets/fortran/userguide.txt ]